### PR TITLE
Export widget intent changes

### DIFF
--- a/af/firefox-ios.xliff
+++ b/af/firefox-ios.xliff
@@ -1,5 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 http://docs.oasis-open.org/xliff/v1.2/os/xliff-core-1.2-strict.xsd">
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?><xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 http://docs.oasis-open.org/xliff/v1.2/os/xliff-core-1.2-strict.xsd">
   <file original="Client/en.lproj/InfoPlist.strings" source-language="en" target-language="af" datatype="plaintext">
     <header>
       <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="13.4.1" build-num="13F100"/>
@@ -187,7 +186,7 @@
       </trans-unit>
     </body>
   </file>
-  <file original="Shared/en.lproj/Default Browser.strings" source-language="en" target-language="af" datatype="plaintext">
+  <file original="Shared/en.lproj/Default Browser.strings" datatype="plaintext" source-language="en" target-language="af">
     <header>
       <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="13.4.1" build-num="13F100"/>
     </header>
@@ -3203,7 +3202,7 @@
       </trans-unit>
     </body>
   </file>
-  <file original="Shared/en.lproj/Today.strings" source-language="en" target-language="af" datatype="plaintext">
+  <file original="Shared/en.lproj/Today.strings" datatype="plaintext" source-language="en" target-language="af">
     <header>
       <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="13.4.1" build-num="13F100"/>
     </header>
@@ -3294,7 +3293,7 @@ Private Tab</source>
       </trans-unit>
     </body>
   </file>
-  <file original="Shared/Supporting Files/en.lproj/BookmarkPanel.strings" datatype="plaintext" source-language="en" target-language="af">
+  <file original="Shared/Supporting Files/en.lproj/BookmarkPanel.strings" source-language="en" target-language="af" datatype="plaintext">
     <header>
       <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="13.4.1" build-num="13F100"/>
     </header>
@@ -3362,66 +3361,82 @@ Private Tab</source>
     <body>
       <trans-unit id="2GqvPe" xml:space="preserve">
         <source>Go to Copied Link</source>
+        <target>Go to Copied Link</target>
         <note>Quick Actions drop down menu item for Go to Copied Link when widget enters edit mode and drop down menu expands</note>
       </trans-unit>
       <trans-unit id="PzSrmZ-2GqvPe" xml:space="preserve">
         <source>Just to confirm, you wanted ‘Go to Copied Link’?</source>
+        <target>Just to confirm, you wanted ‘Go to Copied Link’?</target>
         <note>Accessibility label to confirm the go to copied link selection</note>
       </trans-unit>
       <trans-unit id="PzSrmZ-eHmH1H" xml:space="preserve">
         <source>Just to confirm, you wanted ‘Clear Private Tabs’?</source>
+        <target>Just to confirm, you wanted ‘Clear Private Tabs’?</target>
         <note>Accessibility label to confirm the Clear Private Tabs selection</note>
       </trans-unit>
       <trans-unit id="PzSrmZ-scEmjs" xml:space="preserve">
         <source>Just to confirm, you wanted ‘New Private Search’?</source>
+        <target>Just to confirm, you wanted ‘New Private Search’?</target>
         <note>Accessibility label to confirm the New Private Search selection</note>
       </trans-unit>
       <trans-unit id="PzSrmZ-xRJbBP" xml:space="preserve">
         <source>Just to confirm, you wanted ‘New Search’?</source>
+        <target>Just to confirm, you wanted ‘New Search’?</target>
         <note>Accessibility label to confirm the New Search selection</note>
       </trans-unit>
       <trans-unit id="ctDNmu" xml:space="preserve">
         <source>Quick access to various Firefox actions</source>
+        <target>Quick access to various Firefox actions</target>
         <note>Description of the collection of widgets</note>
       </trans-unit>
       <trans-unit id="eHmH1H" xml:space="preserve">
         <source>Clear Private Tabs</source>
+        <target>Clear Private Tabs</target>
         <note>Quick Actions drop down menu item for lear Private Tabs when widget enters edit mode and drop down menu expands</note>
       </trans-unit>
       <trans-unit id="eV8mOT" xml:space="preserve">
         <source>Quick Action Type</source>
+        <target>Quick Action Type</target>
         <note>The description of a customizable section of the widget</note>
       </trans-unit>
       <trans-unit id="eqyNJg" xml:space="preserve">
         <source>Quick Action</source>
+        <target>Quick Action</target>
         <note>Title of the quick actions widgets</note>
       </trans-unit>
       <trans-unit id="fi3W24-2GqvPe" xml:space="preserve">
         <source>There are ${count} options matching ‘Go to Copied Link’.</source>
+        <target>There are ${count} options matching ‘Go to Copied Link’.</target>
         <note>Label showing how many widgets match ‘Go to Copied Link’. ${count} is a placeholder fo the number of widgets.</note>
       </trans-unit>
       <trans-unit id="fi3W24-eHmH1H" xml:space="preserve">
         <source>There are ${count} options matching ‘Clear Private Tabs’.</source>
+        <target>There are ${count} options matching ‘Clear Private Tabs’.</target>
         <note>Label showing how many widgets match ‘Clear Private Tabs’. ${count} is a placeholder fo the number of widgets.</note>
       </trans-unit>
       <trans-unit id="fi3W24-scEmjs" xml:space="preserve">
         <source>There are ${count} options matching ‘New Private Search’.</source>
+        <target>There are ${count} options matching ‘New Private Search’.</target>
         <note>Label showing how many widgets match ‘New Private Search’. ${count} is a placeholder fo the number of widgets.</note>
       </trans-unit>
       <trans-unit id="fi3W24-xRJbBP" xml:space="preserve">
         <source>There are ${count} options matching ‘New Search’.</source>
+        <target>There are ${count} options matching ‘New Search’.</target>
         <note>Label showing how many widgets match ‘New Search’. ${count} is a placeholder fo the number of widgets.</note>
       </trans-unit>
       <trans-unit id="scEmjs" xml:space="preserve">
         <source>New Private Search</source>
+        <target>New Private Search</target>
         <note>Quick Actions drop down menu item for new private search when widget enters edit mode and drop down menu expands</note>
       </trans-unit>
       <trans-unit id="w9jdPK" xml:space="preserve">
         <source>Quick Action</source>
+        <target>Quick Action</target>
         <note>Quick Actions left label text for dropdown menu when widget enters edit mode</note>
       </trans-unit>
       <trans-unit id="xRJbBP" xml:space="preserve">
         <source>New Search</source>
+        <target>New Search</target>
         <note>Quick Actions drop down menu item for new search when widget enters edit mode and drop down menu expands</note>
       </trans-unit>
     </body>

--- a/an/firefox-ios.xliff
+++ b/an/firefox-ios.xliff
@@ -1,5 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 http://docs.oasis-open.org/xliff/v1.2/os/xliff-core-1.2-strict.xsd">
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?><xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 http://docs.oasis-open.org/xliff/v1.2/os/xliff-core-1.2-strict.xsd">
   <file original="Client/en.lproj/InfoPlist.strings" source-language="en" target-language="an" datatype="plaintext">
     <header>
       <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="13.4.1" build-num="13F100"/>
@@ -3572,7 +3571,7 @@ Private Tab</source>
       </trans-unit>
     </body>
   </file>
-  <file original="Shared/Supporting Files/en.lproj/BookmarkPanel.strings" datatype="plaintext" source-language="en" target-language="an">
+  <file original="Shared/Supporting Files/en.lproj/BookmarkPanel.strings" source-language="en" target-language="an" datatype="plaintext">
     <header>
       <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="13.4.1" build-num="13F100"/>
     </header>
@@ -3640,66 +3639,82 @@ Private Tab</source>
     <body>
       <trans-unit id="2GqvPe" xml:space="preserve">
         <source>Go to Copied Link</source>
+        <target>Go to Copied Link</target>
         <note>Quick Actions drop down menu item for Go to Copied Link when widget enters edit mode and drop down menu expands</note>
       </trans-unit>
       <trans-unit id="PzSrmZ-2GqvPe" xml:space="preserve">
         <source>Just to confirm, you wanted ‘Go to Copied Link’?</source>
+        <target>Just to confirm, you wanted ‘Go to Copied Link’?</target>
         <note>Accessibility label to confirm the go to copied link selection</note>
       </trans-unit>
       <trans-unit id="PzSrmZ-eHmH1H" xml:space="preserve">
         <source>Just to confirm, you wanted ‘Clear Private Tabs’?</source>
+        <target>Just to confirm, you wanted ‘Clear Private Tabs’?</target>
         <note>Accessibility label to confirm the Clear Private Tabs selection</note>
       </trans-unit>
       <trans-unit id="PzSrmZ-scEmjs" xml:space="preserve">
         <source>Just to confirm, you wanted ‘New Private Search’?</source>
+        <target>Just to confirm, you wanted ‘New Private Search’?</target>
         <note>Accessibility label to confirm the New Private Search selection</note>
       </trans-unit>
       <trans-unit id="PzSrmZ-xRJbBP" xml:space="preserve">
         <source>Just to confirm, you wanted ‘New Search’?</source>
+        <target>Just to confirm, you wanted ‘New Search’?</target>
         <note>Accessibility label to confirm the New Search selection</note>
       </trans-unit>
       <trans-unit id="ctDNmu" xml:space="preserve">
         <source>Quick access to various Firefox actions</source>
+        <target>Quick access to various Firefox actions</target>
         <note>Description of the collection of widgets</note>
       </trans-unit>
       <trans-unit id="eHmH1H" xml:space="preserve">
         <source>Clear Private Tabs</source>
+        <target>Clear Private Tabs</target>
         <note>Quick Actions drop down menu item for lear Private Tabs when widget enters edit mode and drop down menu expands</note>
       </trans-unit>
       <trans-unit id="eV8mOT" xml:space="preserve">
         <source>Quick Action Type</source>
+        <target>Quick Action Type</target>
         <note>The description of a customizable section of the widget</note>
       </trans-unit>
       <trans-unit id="eqyNJg" xml:space="preserve">
         <source>Quick Action</source>
+        <target>Quick Action</target>
         <note>Title of the quick actions widgets</note>
       </trans-unit>
       <trans-unit id="fi3W24-2GqvPe" xml:space="preserve">
         <source>There are ${count} options matching ‘Go to Copied Link’.</source>
+        <target>There are ${count} options matching ‘Go to Copied Link’.</target>
         <note>Label showing how many widgets match ‘Go to Copied Link’. ${count} is a placeholder fo the number of widgets.</note>
       </trans-unit>
       <trans-unit id="fi3W24-eHmH1H" xml:space="preserve">
         <source>There are ${count} options matching ‘Clear Private Tabs’.</source>
+        <target>There are ${count} options matching ‘Clear Private Tabs’.</target>
         <note>Label showing how many widgets match ‘Clear Private Tabs’. ${count} is a placeholder fo the number of widgets.</note>
       </trans-unit>
       <trans-unit id="fi3W24-scEmjs" xml:space="preserve">
         <source>There are ${count} options matching ‘New Private Search’.</source>
+        <target>There are ${count} options matching ‘New Private Search’.</target>
         <note>Label showing how many widgets match ‘New Private Search’. ${count} is a placeholder fo the number of widgets.</note>
       </trans-unit>
       <trans-unit id="fi3W24-xRJbBP" xml:space="preserve">
         <source>There are ${count} options matching ‘New Search’.</source>
+        <target>There are ${count} options matching ‘New Search’.</target>
         <note>Label showing how many widgets match ‘New Search’. ${count} is a placeholder fo the number of widgets.</note>
       </trans-unit>
       <trans-unit id="scEmjs" xml:space="preserve">
         <source>New Private Search</source>
+        <target>New Private Search</target>
         <note>Quick Actions drop down menu item for new private search when widget enters edit mode and drop down menu expands</note>
       </trans-unit>
       <trans-unit id="w9jdPK" xml:space="preserve">
         <source>Quick Action</source>
+        <target>Quick Action</target>
         <note>Quick Actions left label text for dropdown menu when widget enters edit mode</note>
       </trans-unit>
       <trans-unit id="xRJbBP" xml:space="preserve">
         <source>New Search</source>
+        <target>New Search</target>
         <note>Quick Actions drop down menu item for new search when widget enters edit mode and drop down menu expands</note>
       </trans-unit>
     </body>

--- a/anp/firefox-ios.xliff
+++ b/anp/firefox-ios.xliff
@@ -1,5 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 http://docs.oasis-open.org/xliff/v1.2/os/xliff-core-1.2-strict.xsd">
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?><xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 http://docs.oasis-open.org/xliff/v1.2/os/xliff-core-1.2-strict.xsd">
   <file original="Client/en.lproj/InfoPlist.strings" source-language="en" target-language="anp" datatype="plaintext">
     <header>
       <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="13.4.1" build-num="13F100"/>
@@ -3263,7 +3262,7 @@
       </trans-unit>
     </body>
   </file>
-  <file original="Shared/en.lproj/Search.strings" source-language="en" target-language="anp" datatype="plaintext">
+  <file original="Shared/en.lproj/Search.strings" datatype="plaintext" source-language="en" target-language="anp">
     <header>
       <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="13.4.1" build-num="13F100"/>
     </header>
@@ -3314,7 +3313,7 @@
       </trans-unit>
     </body>
   </file>
-  <file original="Shared/en.lproj/Today.strings" source-language="en" target-language="anp" datatype="plaintext">
+  <file original="Shared/en.lproj/Today.strings" datatype="plaintext" source-language="en" target-language="anp">
     <header>
       <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="13.4.1" build-num="13F100"/>
     </header>
@@ -3405,7 +3404,7 @@ Private Tab</source>
       </trans-unit>
     </body>
   </file>
-  <file original="Shared/Supporting Files/en.lproj/BookmarkPanel.strings" datatype="plaintext" source-language="en" target-language="anp">
+  <file original="Shared/Supporting Files/en.lproj/BookmarkPanel.strings" source-language="en" target-language="anp" datatype="plaintext">
     <header>
       <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="13.4.1" build-num="13F100"/>
     </header>
@@ -3473,66 +3472,82 @@ Private Tab</source>
     <body>
       <trans-unit id="2GqvPe" xml:space="preserve">
         <source>Go to Copied Link</source>
+        <target>Go to Copied Link</target>
         <note>Quick Actions drop down menu item for Go to Copied Link when widget enters edit mode and drop down menu expands</note>
       </trans-unit>
       <trans-unit id="PzSrmZ-2GqvPe" xml:space="preserve">
         <source>Just to confirm, you wanted ‘Go to Copied Link’?</source>
+        <target>Just to confirm, you wanted ‘Go to Copied Link’?</target>
         <note>Accessibility label to confirm the go to copied link selection</note>
       </trans-unit>
       <trans-unit id="PzSrmZ-eHmH1H" xml:space="preserve">
         <source>Just to confirm, you wanted ‘Clear Private Tabs’?</source>
+        <target>Just to confirm, you wanted ‘Clear Private Tabs’?</target>
         <note>Accessibility label to confirm the Clear Private Tabs selection</note>
       </trans-unit>
       <trans-unit id="PzSrmZ-scEmjs" xml:space="preserve">
         <source>Just to confirm, you wanted ‘New Private Search’?</source>
+        <target>Just to confirm, you wanted ‘New Private Search’?</target>
         <note>Accessibility label to confirm the New Private Search selection</note>
       </trans-unit>
       <trans-unit id="PzSrmZ-xRJbBP" xml:space="preserve">
         <source>Just to confirm, you wanted ‘New Search’?</source>
+        <target>Just to confirm, you wanted ‘New Search’?</target>
         <note>Accessibility label to confirm the New Search selection</note>
       </trans-unit>
       <trans-unit id="ctDNmu" xml:space="preserve">
         <source>Quick access to various Firefox actions</source>
+        <target>Quick access to various Firefox actions</target>
         <note>Description of the collection of widgets</note>
       </trans-unit>
       <trans-unit id="eHmH1H" xml:space="preserve">
         <source>Clear Private Tabs</source>
+        <target>Clear Private Tabs</target>
         <note>Quick Actions drop down menu item for lear Private Tabs when widget enters edit mode and drop down menu expands</note>
       </trans-unit>
       <trans-unit id="eV8mOT" xml:space="preserve">
         <source>Quick Action Type</source>
+        <target>Quick Action Type</target>
         <note>The description of a customizable section of the widget</note>
       </trans-unit>
       <trans-unit id="eqyNJg" xml:space="preserve">
         <source>Quick Action</source>
+        <target>Quick Action</target>
         <note>Title of the quick actions widgets</note>
       </trans-unit>
       <trans-unit id="fi3W24-2GqvPe" xml:space="preserve">
         <source>There are ${count} options matching ‘Go to Copied Link’.</source>
+        <target>There are ${count} options matching ‘Go to Copied Link’.</target>
         <note>Label showing how many widgets match ‘Go to Copied Link’. ${count} is a placeholder fo the number of widgets.</note>
       </trans-unit>
       <trans-unit id="fi3W24-eHmH1H" xml:space="preserve">
         <source>There are ${count} options matching ‘Clear Private Tabs’.</source>
+        <target>There are ${count} options matching ‘Clear Private Tabs’.</target>
         <note>Label showing how many widgets match ‘Clear Private Tabs’. ${count} is a placeholder fo the number of widgets.</note>
       </trans-unit>
       <trans-unit id="fi3W24-scEmjs" xml:space="preserve">
         <source>There are ${count} options matching ‘New Private Search’.</source>
+        <target>There are ${count} options matching ‘New Private Search’.</target>
         <note>Label showing how many widgets match ‘New Private Search’. ${count} is a placeholder fo the number of widgets.</note>
       </trans-unit>
       <trans-unit id="fi3W24-xRJbBP" xml:space="preserve">
         <source>There are ${count} options matching ‘New Search’.</source>
+        <target>There are ${count} options matching ‘New Search’.</target>
         <note>Label showing how many widgets match ‘New Search’. ${count} is a placeholder fo the number of widgets.</note>
       </trans-unit>
       <trans-unit id="scEmjs" xml:space="preserve">
         <source>New Private Search</source>
+        <target>New Private Search</target>
         <note>Quick Actions drop down menu item for new private search when widget enters edit mode and drop down menu expands</note>
       </trans-unit>
       <trans-unit id="w9jdPK" xml:space="preserve">
         <source>Quick Action</source>
+        <target>Quick Action</target>
         <note>Quick Actions left label text for dropdown menu when widget enters edit mode</note>
       </trans-unit>
       <trans-unit id="xRJbBP" xml:space="preserve">
         <source>New Search</source>
+        <target>New Search</target>
         <note>Quick Actions drop down menu item for new search when widget enters edit mode and drop down menu expands</note>
       </trans-unit>
     </body>

--- a/ast/firefox-ios.xliff
+++ b/ast/firefox-ios.xliff
@@ -1,5 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 http://docs.oasis-open.org/xliff/v1.2/os/xliff-core-1.2-strict.xsd">
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?><xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 http://docs.oasis-open.org/xliff/v1.2/os/xliff-core-1.2-strict.xsd">
   <file original="Client/en.lproj/InfoPlist.strings" source-language="en" target-language="ast" datatype="plaintext">
     <header>
       <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="13.4.1" build-num="13F100"/>
@@ -3509,7 +3508,7 @@ Private Tab</source>
       </trans-unit>
     </body>
   </file>
-  <file original="Shared/Supporting Files/en.lproj/BookmarkPanel.strings" datatype="plaintext" source-language="en" target-language="ast">
+  <file original="Shared/Supporting Files/en.lproj/BookmarkPanel.strings" source-language="en" target-language="ast" datatype="plaintext">
     <header>
       <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="13.4.1" build-num="13F100"/>
     </header>
@@ -3521,7 +3520,7 @@ Private Tab</source>
       </trans-unit>
     </body>
   </file>
-  <file original="Shared/Supporting Files/en.lproj/BookmarkPanelDeleteConfirm.strings" datatype="plaintext" source-language="en" target-language="ast">
+  <file original="Shared/Supporting Files/en.lproj/BookmarkPanelDeleteConfirm.strings" source-language="en" target-language="ast" datatype="plaintext">
     <header>
       <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="13.4.1" build-num="13F100"/>
     </header>
@@ -3580,34 +3579,42 @@ Private Tab</source>
     <body>
       <trans-unit id="2GqvPe" xml:space="preserve">
         <source>Go to Copied Link</source>
+        <target>Siirry kopioituun linkkiin</target>
         <note>Quick Actions drop down menu item for Go to Copied Link when widget enters edit mode and drop down menu expands</note>
       </trans-unit>
       <trans-unit id="PzSrmZ-2GqvPe" xml:space="preserve">
         <source>Just to confirm, you wanted ‘Go to Copied Link’?</source>
+        <target>Just to confirm, you wanted ‘Go to Copied Link’?</target>
         <note>Accessibility label to confirm the go to copied link selection</note>
       </trans-unit>
       <trans-unit id="PzSrmZ-eHmH1H" xml:space="preserve">
         <source>Just to confirm, you wanted ‘Clear Private Tabs’?</source>
+        <target>Just to confirm, you wanted ‘Clear Private Tabs’?</target>
         <note>Accessibility label to confirm the Clear Private Tabs selection</note>
       </trans-unit>
       <trans-unit id="PzSrmZ-scEmjs" xml:space="preserve">
         <source>Just to confirm, you wanted ‘New Private Search’?</source>
+        <target>Just to confirm, you wanted ‘New Private Search’?</target>
         <note>Accessibility label to confirm the New Private Search selection</note>
       </trans-unit>
       <trans-unit id="PzSrmZ-xRJbBP" xml:space="preserve">
         <source>Just to confirm, you wanted ‘New Search’?</source>
+        <target>Just to confirm, you wanted ‘New Search’?</target>
         <note>Accessibility label to confirm the New Search selection</note>
       </trans-unit>
       <trans-unit id="ctDNmu" xml:space="preserve">
         <source>Quick access to various Firefox actions</source>
+        <target>Quick access to various Firefox actions</target>
         <note>Description of the collection of widgets</note>
       </trans-unit>
       <trans-unit id="eHmH1H" xml:space="preserve">
         <source>Clear Private Tabs</source>
+        <target>Clear Private Tabs</target>
         <note>Quick Actions drop down menu item for lear Private Tabs when widget enters edit mode and drop down menu expands</note>
       </trans-unit>
       <trans-unit id="eV8mOT" xml:space="preserve">
         <source>Quick Action Type</source>
+        <target>Quick Action Type</target>
         <note>The description of a customizable section of the widget</note>
       </trans-unit>
       <trans-unit id="eqyNJg" xml:space="preserve">
@@ -3617,18 +3624,22 @@ Private Tab</source>
       </trans-unit>
       <trans-unit id="fi3W24-2GqvPe" xml:space="preserve">
         <source>There are ${count} options matching ‘Go to Copied Link’.</source>
+        <target>There are ${count} options matching ‘Go to Copied Link’.</target>
         <note>Label showing how many widgets match ‘Go to Copied Link’. ${count} is a placeholder fo the number of widgets.</note>
       </trans-unit>
       <trans-unit id="fi3W24-eHmH1H" xml:space="preserve">
         <source>There are ${count} options matching ‘Clear Private Tabs’.</source>
+        <target>There are ${count} options matching ‘Clear Private Tabs’.</target>
         <note>Label showing how many widgets match ‘Clear Private Tabs’. ${count} is a placeholder fo the number of widgets.</note>
       </trans-unit>
       <trans-unit id="fi3W24-scEmjs" xml:space="preserve">
         <source>There are ${count} options matching ‘New Private Search’.</source>
+        <target>There are ${count} options matching ‘New Private Search’.</target>
         <note>Label showing how many widgets match ‘New Private Search’. ${count} is a placeholder fo the number of widgets.</note>
       </trans-unit>
       <trans-unit id="fi3W24-xRJbBP" xml:space="preserve">
         <source>There are ${count} options matching ‘New Search’.</source>
+        <target>There are ${count} options matching ‘New Search’.</target>
         <note>Label showing how many widgets match ‘New Search’. ${count} is a placeholder fo the number of widgets.</note>
       </trans-unit>
       <trans-unit id="scEmjs" xml:space="preserve">

--- a/az/firefox-ios.xliff
+++ b/az/firefox-ios.xliff
@@ -1,5 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 http://docs.oasis-open.org/xliff/v1.2/os/xliff-core-1.2-strict.xsd">
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?><xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 http://docs.oasis-open.org/xliff/v1.2/os/xliff-core-1.2-strict.xsd">
   <file original="Client/en.lproj/InfoPlist.strings" source-language="en" target-language="az" datatype="plaintext">
     <header>
       <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="13.4.1" build-num="13F100"/>
@@ -3564,7 +3563,7 @@ Private Tab</source>
       </trans-unit>
     </body>
   </file>
-  <file original="Shared/Supporting Files/en.lproj/BookmarkPanel.strings" datatype="plaintext" source-language="en" target-language="az">
+  <file original="Shared/Supporting Files/en.lproj/BookmarkPanel.strings" source-language="en" target-language="az" datatype="plaintext">
     <header>
       <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="13.4.1" build-num="13F100"/>
     </header>
@@ -3632,66 +3631,82 @@ Private Tab</source>
     <body>
       <trans-unit id="2GqvPe" xml:space="preserve">
         <source>Go to Copied Link</source>
+        <target>Go to Copied Link</target>
         <note>Quick Actions drop down menu item for Go to Copied Link when widget enters edit mode and drop down menu expands</note>
       </trans-unit>
       <trans-unit id="PzSrmZ-2GqvPe" xml:space="preserve">
         <source>Just to confirm, you wanted ‘Go to Copied Link’?</source>
+        <target>Just to confirm, you wanted ‘Go to Copied Link’?</target>
         <note>Accessibility label to confirm the go to copied link selection</note>
       </trans-unit>
       <trans-unit id="PzSrmZ-eHmH1H" xml:space="preserve">
         <source>Just to confirm, you wanted ‘Clear Private Tabs’?</source>
+        <target>Just to confirm, you wanted ‘Clear Private Tabs’?</target>
         <note>Accessibility label to confirm the Clear Private Tabs selection</note>
       </trans-unit>
       <trans-unit id="PzSrmZ-scEmjs" xml:space="preserve">
         <source>Just to confirm, you wanted ‘New Private Search’?</source>
+        <target>Just to confirm, you wanted ‘New Private Search’?</target>
         <note>Accessibility label to confirm the New Private Search selection</note>
       </trans-unit>
       <trans-unit id="PzSrmZ-xRJbBP" xml:space="preserve">
         <source>Just to confirm, you wanted ‘New Search’?</source>
+        <target>Just to confirm, you wanted ‘New Search’?</target>
         <note>Accessibility label to confirm the New Search selection</note>
       </trans-unit>
       <trans-unit id="ctDNmu" xml:space="preserve">
         <source>Quick access to various Firefox actions</source>
+        <target>Quick access to various Firefox actions</target>
         <note>Description of the collection of widgets</note>
       </trans-unit>
       <trans-unit id="eHmH1H" xml:space="preserve">
         <source>Clear Private Tabs</source>
+        <target>Clear Private Tabs</target>
         <note>Quick Actions drop down menu item for lear Private Tabs when widget enters edit mode and drop down menu expands</note>
       </trans-unit>
       <trans-unit id="eV8mOT" xml:space="preserve">
         <source>Quick Action Type</source>
+        <target>Quick Action Type</target>
         <note>The description of a customizable section of the widget</note>
       </trans-unit>
       <trans-unit id="eqyNJg" xml:space="preserve">
         <source>Quick Action</source>
+        <target>Quick Action</target>
         <note>Title of the quick actions widgets</note>
       </trans-unit>
       <trans-unit id="fi3W24-2GqvPe" xml:space="preserve">
         <source>There are ${count} options matching ‘Go to Copied Link’.</source>
+        <target>There are ${count} options matching ‘Go to Copied Link’.</target>
         <note>Label showing how many widgets match ‘Go to Copied Link’. ${count} is a placeholder fo the number of widgets.</note>
       </trans-unit>
       <trans-unit id="fi3W24-eHmH1H" xml:space="preserve">
         <source>There are ${count} options matching ‘Clear Private Tabs’.</source>
+        <target>There are ${count} options matching ‘Clear Private Tabs’.</target>
         <note>Label showing how many widgets match ‘Clear Private Tabs’. ${count} is a placeholder fo the number of widgets.</note>
       </trans-unit>
       <trans-unit id="fi3W24-scEmjs" xml:space="preserve">
         <source>There are ${count} options matching ‘New Private Search’.</source>
+        <target>There are ${count} options matching ‘New Private Search’.</target>
         <note>Label showing how many widgets match ‘New Private Search’. ${count} is a placeholder fo the number of widgets.</note>
       </trans-unit>
       <trans-unit id="fi3W24-xRJbBP" xml:space="preserve">
         <source>There are ${count} options matching ‘New Search’.</source>
+        <target>There are ${count} options matching ‘New Search’.</target>
         <note>Label showing how many widgets match ‘New Search’. ${count} is a placeholder fo the number of widgets.</note>
       </trans-unit>
       <trans-unit id="scEmjs" xml:space="preserve">
         <source>New Private Search</source>
+        <target>New Private Search</target>
         <note>Quick Actions drop down menu item for new private search when widget enters edit mode and drop down menu expands</note>
       </trans-unit>
       <trans-unit id="w9jdPK" xml:space="preserve">
         <source>Quick Action</source>
+        <target>Quick Action</target>
         <note>Quick Actions left label text for dropdown menu when widget enters edit mode</note>
       </trans-unit>
       <trans-unit id="xRJbBP" xml:space="preserve">
         <source>New Search</source>
+        <target>New Search</target>
         <note>Quick Actions drop down menu item for new search when widget enters edit mode and drop down menu expands</note>
       </trans-unit>
     </body>

--- a/be/firefox-ios.xliff
+++ b/be/firefox-ios.xliff
@@ -1,5 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 http://docs.oasis-open.org/xliff/v1.2/os/xliff-core-1.2-strict.xsd">
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?><xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 http://docs.oasis-open.org/xliff/v1.2/os/xliff-core-1.2-strict.xsd">
   <file original="Client/en.lproj/InfoPlist.strings" source-language="en" target-language="be" datatype="plaintext">
     <header>
       <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="13.4.1" build-num="13F100"/>
@@ -3116,7 +3115,7 @@
       </trans-unit>
     </body>
   </file>
-  <file original="Shared/en.lproj/Menu.strings" source-language="en" target-language="be" datatype="plaintext">
+  <file original="Shared/en.lproj/Menu.strings" datatype="plaintext" source-language="en" target-language="be">
     <header>
       <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="13.4.1" build-num="13F100"/>
     </header>
@@ -3199,7 +3198,7 @@
       </trans-unit>
     </body>
   </file>
-  <file original="Shared/en.lproj/PrivateBrowsing.strings" source-language="en" target-language="be" datatype="plaintext">
+  <file original="Shared/en.lproj/PrivateBrowsing.strings" datatype="plaintext" source-language="en" target-language="be">
     <header>
       <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="13.4.1" build-num="13F100"/>
     </header>
@@ -3246,7 +3245,7 @@
       </trans-unit>
     </body>
   </file>
-  <file original="Shared/en.lproj/Search.strings" source-language="en" target-language="be" datatype="plaintext">
+  <file original="Shared/en.lproj/Search.strings" datatype="plaintext" source-language="en" target-language="be">
     <header>
       <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="13.4.1" build-num="13F100"/>
     </header>
@@ -3261,7 +3260,7 @@
       </trans-unit>
     </body>
   </file>
-  <file original="Shared/en.lproj/Shared.strings" source-language="en" target-language="be" datatype="plaintext">
+  <file original="Shared/en.lproj/Shared.strings" datatype="plaintext" source-language="en" target-language="be">
     <header>
       <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="13.4.1" build-num="13F100"/>
     </header>
@@ -3272,7 +3271,7 @@
       </trans-unit>
     </body>
   </file>
-  <file original="Shared/en.lproj/Storage.strings" source-language="en" target-language="be" datatype="plaintext">
+  <file original="Shared/en.lproj/Storage.strings" datatype="plaintext" source-language="en" target-language="be">
     <header>
       <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="13.4.1" build-num="13F100"/>
     </header>
@@ -3295,7 +3294,7 @@
       </trans-unit>
     </body>
   </file>
-  <file original="Shared/en.lproj/Today.strings" source-language="en" target-language="be" datatype="plaintext">
+  <file original="Shared/en.lproj/Today.strings" datatype="plaintext" source-language="en" target-language="be">
     <header>
       <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="13.4.1" build-num="13F100"/>
     </header>
@@ -3386,7 +3385,7 @@ Private Tab</source>
       </trans-unit>
     </body>
   </file>
-  <file original="Shared/Supporting Files/en.lproj/BookmarkPanel.strings" datatype="plaintext" source-language="en" target-language="be">
+  <file original="Shared/Supporting Files/en.lproj/BookmarkPanel.strings" source-language="en" target-language="be" datatype="plaintext">
     <header>
       <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="13.4.1" build-num="13F100"/>
     </header>
@@ -3454,66 +3453,82 @@ Private Tab</source>
     <body>
       <trans-unit id="2GqvPe" xml:space="preserve">
         <source>Go to Copied Link</source>
+        <target>Go to Copied Link</target>
         <note>Quick Actions drop down menu item for Go to Copied Link when widget enters edit mode and drop down menu expands</note>
       </trans-unit>
       <trans-unit id="PzSrmZ-2GqvPe" xml:space="preserve">
         <source>Just to confirm, you wanted ‘Go to Copied Link’?</source>
+        <target>Just to confirm, you wanted ‘Go to Copied Link’?</target>
         <note>Accessibility label to confirm the go to copied link selection</note>
       </trans-unit>
       <trans-unit id="PzSrmZ-eHmH1H" xml:space="preserve">
         <source>Just to confirm, you wanted ‘Clear Private Tabs’?</source>
+        <target>Just to confirm, you wanted ‘Clear Private Tabs’?</target>
         <note>Accessibility label to confirm the Clear Private Tabs selection</note>
       </trans-unit>
       <trans-unit id="PzSrmZ-scEmjs" xml:space="preserve">
         <source>Just to confirm, you wanted ‘New Private Search’?</source>
+        <target>Just to confirm, you wanted ‘New Private Search’?</target>
         <note>Accessibility label to confirm the New Private Search selection</note>
       </trans-unit>
       <trans-unit id="PzSrmZ-xRJbBP" xml:space="preserve">
         <source>Just to confirm, you wanted ‘New Search’?</source>
+        <target>Just to confirm, you wanted ‘New Search’?</target>
         <note>Accessibility label to confirm the New Search selection</note>
       </trans-unit>
       <trans-unit id="ctDNmu" xml:space="preserve">
         <source>Quick access to various Firefox actions</source>
+        <target>Quick access to various Firefox actions</target>
         <note>Description of the collection of widgets</note>
       </trans-unit>
       <trans-unit id="eHmH1H" xml:space="preserve">
         <source>Clear Private Tabs</source>
+        <target>Clear Private Tabs</target>
         <note>Quick Actions drop down menu item for lear Private Tabs when widget enters edit mode and drop down menu expands</note>
       </trans-unit>
       <trans-unit id="eV8mOT" xml:space="preserve">
         <source>Quick Action Type</source>
+        <target>Quick Action Type</target>
         <note>The description of a customizable section of the widget</note>
       </trans-unit>
       <trans-unit id="eqyNJg" xml:space="preserve">
         <source>Quick Action</source>
+        <target>Quick Action</target>
         <note>Title of the quick actions widgets</note>
       </trans-unit>
       <trans-unit id="fi3W24-2GqvPe" xml:space="preserve">
         <source>There are ${count} options matching ‘Go to Copied Link’.</source>
+        <target>There are ${count} options matching ‘Go to Copied Link’.</target>
         <note>Label showing how many widgets match ‘Go to Copied Link’. ${count} is a placeholder fo the number of widgets.</note>
       </trans-unit>
       <trans-unit id="fi3W24-eHmH1H" xml:space="preserve">
         <source>There are ${count} options matching ‘Clear Private Tabs’.</source>
+        <target>There are ${count} options matching ‘Clear Private Tabs’.</target>
         <note>Label showing how many widgets match ‘Clear Private Tabs’. ${count} is a placeholder fo the number of widgets.</note>
       </trans-unit>
       <trans-unit id="fi3W24-scEmjs" xml:space="preserve">
         <source>There are ${count} options matching ‘New Private Search’.</source>
+        <target>There are ${count} options matching ‘New Private Search’.</target>
         <note>Label showing how many widgets match ‘New Private Search’. ${count} is a placeholder fo the number of widgets.</note>
       </trans-unit>
       <trans-unit id="fi3W24-xRJbBP" xml:space="preserve">
         <source>There are ${count} options matching ‘New Search’.</source>
+        <target>There are ${count} options matching ‘New Search’.</target>
         <note>Label showing how many widgets match ‘New Search’. ${count} is a placeholder fo the number of widgets.</note>
       </trans-unit>
       <trans-unit id="scEmjs" xml:space="preserve">
         <source>New Private Search</source>
+        <target>New Private Search</target>
         <note>Quick Actions drop down menu item for new private search when widget enters edit mode and drop down menu expands</note>
       </trans-unit>
       <trans-unit id="w9jdPK" xml:space="preserve">
         <source>Quick Action</source>
+        <target>Quick Action</target>
         <note>Quick Actions left label text for dropdown menu when widget enters edit mode</note>
       </trans-unit>
       <trans-unit id="xRJbBP" xml:space="preserve">
         <source>New Search</source>
+        <target>New Search</target>
         <note>Quick Actions drop down menu item for new search when widget enters edit mode and drop down menu expands</note>
       </trans-unit>
     </body>

--- a/bg/firefox-ios.xliff
+++ b/bg/firefox-ios.xliff
@@ -1,5 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 http://docs.oasis-open.org/xliff/v1.2/os/xliff-core-1.2-strict.xsd">
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?><xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 http://docs.oasis-open.org/xliff/v1.2/os/xliff-core-1.2-strict.xsd">
   <file original="Client/en.lproj/InfoPlist.strings" source-language="en" target-language="bg" datatype="plaintext">
     <header>
       <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="13.4.1" build-num="13F100"/>
@@ -189,7 +188,7 @@
       </trans-unit>
     </body>
   </file>
-  <file original="Shared/en.lproj/Default Browser.strings" source-language="en" target-language="bg" datatype="plaintext">
+  <file original="Shared/en.lproj/Default Browser.strings" datatype="plaintext" source-language="en" target-language="bg">
     <header>
       <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="13.4.1" build-num="13F100"/>
     </header>
@@ -3483,7 +3482,7 @@ Private Tab</source>
       </trans-unit>
     </body>
   </file>
-  <file original="Shared/Supporting Files/en.lproj/BookmarkPanel.strings" datatype="plaintext" source-language="en" target-language="bg">
+  <file original="Shared/Supporting Files/en.lproj/BookmarkPanel.strings" source-language="en" target-language="bg" datatype="plaintext">
     <header>
       <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="13.4.1" build-num="13F100"/>
     </header>
@@ -3551,66 +3550,82 @@ Private Tab</source>
     <body>
       <trans-unit id="2GqvPe" xml:space="preserve">
         <source>Go to Copied Link</source>
+        <target>Go to Copied Link</target>
         <note>Quick Actions drop down menu item for Go to Copied Link when widget enters edit mode and drop down menu expands</note>
       </trans-unit>
       <trans-unit id="PzSrmZ-2GqvPe" xml:space="preserve">
         <source>Just to confirm, you wanted ‘Go to Copied Link’?</source>
+        <target>Just to confirm, you wanted ‘Go to Copied Link’?</target>
         <note>Accessibility label to confirm the go to copied link selection</note>
       </trans-unit>
       <trans-unit id="PzSrmZ-eHmH1H" xml:space="preserve">
         <source>Just to confirm, you wanted ‘Clear Private Tabs’?</source>
+        <target>Just to confirm, you wanted ‘Clear Private Tabs’?</target>
         <note>Accessibility label to confirm the Clear Private Tabs selection</note>
       </trans-unit>
       <trans-unit id="PzSrmZ-scEmjs" xml:space="preserve">
         <source>Just to confirm, you wanted ‘New Private Search’?</source>
+        <target>Just to confirm, you wanted ‘New Private Search’?</target>
         <note>Accessibility label to confirm the New Private Search selection</note>
       </trans-unit>
       <trans-unit id="PzSrmZ-xRJbBP" xml:space="preserve">
         <source>Just to confirm, you wanted ‘New Search’?</source>
+        <target>Just to confirm, you wanted ‘New Search’?</target>
         <note>Accessibility label to confirm the New Search selection</note>
       </trans-unit>
       <trans-unit id="ctDNmu" xml:space="preserve">
         <source>Quick access to various Firefox actions</source>
+        <target>Quick access to various Firefox actions</target>
         <note>Description of the collection of widgets</note>
       </trans-unit>
       <trans-unit id="eHmH1H" xml:space="preserve">
         <source>Clear Private Tabs</source>
+        <target>Clear Private Tabs</target>
         <note>Quick Actions drop down menu item for lear Private Tabs when widget enters edit mode and drop down menu expands</note>
       </trans-unit>
       <trans-unit id="eV8mOT" xml:space="preserve">
         <source>Quick Action Type</source>
+        <target>Quick Action Type</target>
         <note>The description of a customizable section of the widget</note>
       </trans-unit>
       <trans-unit id="eqyNJg" xml:space="preserve">
         <source>Quick Action</source>
+        <target>Quick Action</target>
         <note>Title of the quick actions widgets</note>
       </trans-unit>
       <trans-unit id="fi3W24-2GqvPe" xml:space="preserve">
         <source>There are ${count} options matching ‘Go to Copied Link’.</source>
+        <target>There are ${count} options matching ‘Go to Copied Link’.</target>
         <note>Label showing how many widgets match ‘Go to Copied Link’. ${count} is a placeholder fo the number of widgets.</note>
       </trans-unit>
       <trans-unit id="fi3W24-eHmH1H" xml:space="preserve">
         <source>There are ${count} options matching ‘Clear Private Tabs’.</source>
+        <target>There are ${count} options matching ‘Clear Private Tabs’.</target>
         <note>Label showing how many widgets match ‘Clear Private Tabs’. ${count} is a placeholder fo the number of widgets.</note>
       </trans-unit>
       <trans-unit id="fi3W24-scEmjs" xml:space="preserve">
         <source>There are ${count} options matching ‘New Private Search’.</source>
+        <target>There are ${count} options matching ‘New Private Search’.</target>
         <note>Label showing how many widgets match ‘New Private Search’. ${count} is a placeholder fo the number of widgets.</note>
       </trans-unit>
       <trans-unit id="fi3W24-xRJbBP" xml:space="preserve">
         <source>There are ${count} options matching ‘New Search’.</source>
+        <target>There are ${count} options matching ‘New Search’.</target>
         <note>Label showing how many widgets match ‘New Search’. ${count} is a placeholder fo the number of widgets.</note>
       </trans-unit>
       <trans-unit id="scEmjs" xml:space="preserve">
         <source>New Private Search</source>
+        <target>New Private Search</target>
         <note>Quick Actions drop down menu item for new private search when widget enters edit mode and drop down menu expands</note>
       </trans-unit>
       <trans-unit id="w9jdPK" xml:space="preserve">
         <source>Quick Action</source>
+        <target>Quick Action</target>
         <note>Quick Actions left label text for dropdown menu when widget enters edit mode</note>
       </trans-unit>
       <trans-unit id="xRJbBP" xml:space="preserve">
         <source>New Search</source>
+        <target>New Search</target>
         <note>Quick Actions drop down menu item for new search when widget enters edit mode and drop down menu expands</note>
       </trans-unit>
     </body>

--- a/bo/firefox-ios.xliff
+++ b/bo/firefox-ios.xliff
@@ -1,5 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 http://docs.oasis-open.org/xliff/v1.2/os/xliff-core-1.2-strict.xsd">
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?><xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 http://docs.oasis-open.org/xliff/v1.2/os/xliff-core-1.2-strict.xsd">
   <file original="Client/en.lproj/InfoPlist.strings" source-language="en" target-language="bo" datatype="plaintext">
     <header>
       <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="13.4.1" build-num="13F100"/>
@@ -46,7 +45,7 @@
       </trans-unit>
     </body>
   </file>
-  <file original="Shared/en.lproj/3DTouchActions.strings" source-language="en" target-language="bo" datatype="plaintext">
+  <file original="Shared/en.lproj/3DTouchActions.strings" datatype="plaintext" source-language="en" target-language="bo">
     <header>
       <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="13.4.1" build-num="13F100"/>
     </header>
@@ -81,7 +80,7 @@
       </trans-unit>
     </body>
   </file>
-  <file original="Shared/en.lproj/AuthenticationManager.strings" source-language="en" target-language="bo" datatype="plaintext">
+  <file original="Shared/en.lproj/AuthenticationManager.strings" datatype="plaintext" source-language="en" target-language="bo">
     <header>
       <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="13.4.1" build-num="13F100"/>
     </header>
@@ -117,7 +116,7 @@
       </trans-unit>
     </body>
   </file>
-  <file original="Shared/en.lproj/ClearPrivateData.strings" source-language="en" target-language="bo" datatype="plaintext">
+  <file original="Shared/en.lproj/ClearPrivateData.strings" datatype="plaintext" source-language="en" target-language="bo">
     <header>
       <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="13.4.1" build-num="13F100"/>
     </header>
@@ -173,7 +172,7 @@
       </trans-unit>
     </body>
   </file>
-  <file original="Shared/en.lproj/Default Browser.strings" source-language="en" target-language="bo" datatype="plaintext">
+  <file original="Shared/en.lproj/Default Browser.strings" datatype="plaintext" source-language="en" target-language="bo">
     <header>
       <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="13.4.1" build-num="13F100"/>
     </header>
@@ -216,7 +215,7 @@
       </trans-unit>
     </body>
   </file>
-  <file original="Shared/en.lproj/ErrorPages.strings" source-language="en" target-language="bo" datatype="plaintext">
+  <file original="Shared/en.lproj/ErrorPages.strings" datatype="plaintext" source-language="en" target-language="bo">
     <header>
       <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="13.4.1" build-num="13F100"/>
     </header>
@@ -231,7 +230,7 @@
       </trans-unit>
     </body>
   </file>
-  <file original="Shared/en.lproj/FindInPage.strings" source-language="en" target-language="bo" datatype="plaintext">
+  <file original="Shared/en.lproj/FindInPage.strings" datatype="plaintext" source-language="en" target-language="bo">
     <header>
       <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="13.4.1" build-num="13F100"/>
     </header>
@@ -266,7 +265,7 @@
       </trans-unit>
     </body>
   </file>
-  <file original="Shared/en.lproj/Intro.strings" source-language="en" target-language="bo" datatype="plaintext">
+  <file original="Shared/en.lproj/Intro.strings" datatype="plaintext" source-language="en" target-language="bo">
     <header>
       <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="13.4.1" build-num="13F100"/>
     </header>
@@ -2833,7 +2832,7 @@
       </trans-unit>
     </body>
   </file>
-  <file original="Shared/en.lproj/Menu.strings" source-language="en" target-language="bo" datatype="plaintext">
+  <file original="Shared/en.lproj/Menu.strings" datatype="plaintext" source-language="en" target-language="bo">
     <header>
       <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="13.4.1" build-num="13F100"/>
     </header>
@@ -2916,7 +2915,7 @@
       </trans-unit>
     </body>
   </file>
-  <file original="Shared/en.lproj/PrivateBrowsing.strings" source-language="en" target-language="bo" datatype="plaintext">
+  <file original="Shared/en.lproj/PrivateBrowsing.strings" datatype="plaintext" source-language="en" target-language="bo">
     <header>
       <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="13.4.1" build-num="13F100"/>
     </header>
@@ -2980,7 +2979,7 @@
       </trans-unit>
     </body>
   </file>
-  <file original="Shared/en.lproj/Shared.strings" source-language="en" target-language="bo" datatype="plaintext">
+  <file original="Shared/en.lproj/Shared.strings" datatype="plaintext" source-language="en" target-language="bo">
     <header>
       <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="13.4.1" build-num="13F100"/>
     </header>
@@ -2991,7 +2990,7 @@
       </trans-unit>
     </body>
   </file>
-  <file original="Shared/en.lproj/Storage.strings" source-language="en" target-language="bo" datatype="plaintext">
+  <file original="Shared/en.lproj/Storage.strings" datatype="plaintext" source-language="en" target-language="bo">
     <header>
       <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="13.4.1" build-num="13F100"/>
     </header>
@@ -3014,7 +3013,7 @@
       </trans-unit>
     </body>
   </file>
-  <file original="Shared/en.lproj/Today.strings" source-language="en" target-language="bo" datatype="plaintext">
+  <file original="Shared/en.lproj/Today.strings" datatype="plaintext" source-language="en" target-language="bo">
     <header>
       <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="13.4.1" build-num="13F100"/>
     </header>
@@ -3105,7 +3104,7 @@ Private Tab</source>
       </trans-unit>
     </body>
   </file>
-  <file original="Shared/Supporting Files/en.lproj/BookmarkPanel.strings" datatype="plaintext" source-language="en" target-language="bo">
+  <file original="Shared/Supporting Files/en.lproj/BookmarkPanel.strings" source-language="en" target-language="bo" datatype="plaintext">
     <header>
       <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="13.4.1" build-num="13F100"/>
     </header>
@@ -3173,66 +3172,82 @@ Private Tab</source>
     <body>
       <trans-unit id="2GqvPe" xml:space="preserve">
         <source>Go to Copied Link</source>
+        <target>Go to Copied Link</target>
         <note>Quick Actions drop down menu item for Go to Copied Link when widget enters edit mode and drop down menu expands</note>
       </trans-unit>
       <trans-unit id="PzSrmZ-2GqvPe" xml:space="preserve">
         <source>Just to confirm, you wanted ‘Go to Copied Link’?</source>
+        <target>Just to confirm, you wanted ‘Go to Copied Link’?</target>
         <note>Accessibility label to confirm the go to copied link selection</note>
       </trans-unit>
       <trans-unit id="PzSrmZ-eHmH1H" xml:space="preserve">
         <source>Just to confirm, you wanted ‘Clear Private Tabs’?</source>
+        <target>Just to confirm, you wanted ‘Clear Private Tabs’?</target>
         <note>Accessibility label to confirm the Clear Private Tabs selection</note>
       </trans-unit>
       <trans-unit id="PzSrmZ-scEmjs" xml:space="preserve">
         <source>Just to confirm, you wanted ‘New Private Search’?</source>
+        <target>Just to confirm, you wanted ‘New Private Search’?</target>
         <note>Accessibility label to confirm the New Private Search selection</note>
       </trans-unit>
       <trans-unit id="PzSrmZ-xRJbBP" xml:space="preserve">
         <source>Just to confirm, you wanted ‘New Search’?</source>
+        <target>Just to confirm, you wanted ‘New Search’?</target>
         <note>Accessibility label to confirm the New Search selection</note>
       </trans-unit>
       <trans-unit id="ctDNmu" xml:space="preserve">
         <source>Quick access to various Firefox actions</source>
+        <target>Quick access to various Firefox actions</target>
         <note>Description of the collection of widgets</note>
       </trans-unit>
       <trans-unit id="eHmH1H" xml:space="preserve">
         <source>Clear Private Tabs</source>
+        <target>Clear Private Tabs</target>
         <note>Quick Actions drop down menu item for lear Private Tabs when widget enters edit mode and drop down menu expands</note>
       </trans-unit>
       <trans-unit id="eV8mOT" xml:space="preserve">
         <source>Quick Action Type</source>
+        <target>Quick Action Type</target>
         <note>The description of a customizable section of the widget</note>
       </trans-unit>
       <trans-unit id="eqyNJg" xml:space="preserve">
         <source>Quick Action</source>
+        <target>Quick Action</target>
         <note>Title of the quick actions widgets</note>
       </trans-unit>
       <trans-unit id="fi3W24-2GqvPe" xml:space="preserve">
         <source>There are ${count} options matching ‘Go to Copied Link’.</source>
+        <target>There are ${count} options matching ‘Go to Copied Link’.</target>
         <note>Label showing how many widgets match ‘Go to Copied Link’. ${count} is a placeholder fo the number of widgets.</note>
       </trans-unit>
       <trans-unit id="fi3W24-eHmH1H" xml:space="preserve">
         <source>There are ${count} options matching ‘Clear Private Tabs’.</source>
+        <target>There are ${count} options matching ‘Clear Private Tabs’.</target>
         <note>Label showing how many widgets match ‘Clear Private Tabs’. ${count} is a placeholder fo the number of widgets.</note>
       </trans-unit>
       <trans-unit id="fi3W24-scEmjs" xml:space="preserve">
         <source>There are ${count} options matching ‘New Private Search’.</source>
+        <target>There are ${count} options matching ‘New Private Search’.</target>
         <note>Label showing how many widgets match ‘New Private Search’. ${count} is a placeholder fo the number of widgets.</note>
       </trans-unit>
       <trans-unit id="fi3W24-xRJbBP" xml:space="preserve">
         <source>There are ${count} options matching ‘New Search’.</source>
+        <target>There are ${count} options matching ‘New Search’.</target>
         <note>Label showing how many widgets match ‘New Search’. ${count} is a placeholder fo the number of widgets.</note>
       </trans-unit>
       <trans-unit id="scEmjs" xml:space="preserve">
         <source>New Private Search</source>
+        <target>New Private Search</target>
         <note>Quick Actions drop down menu item for new private search when widget enters edit mode and drop down menu expands</note>
       </trans-unit>
       <trans-unit id="w9jdPK" xml:space="preserve">
         <source>Quick Action</source>
+        <target>Quick Action</target>
         <note>Quick Actions left label text for dropdown menu when widget enters edit mode</note>
       </trans-unit>
       <trans-unit id="xRJbBP" xml:space="preserve">
         <source>New Search</source>
+        <target>New Search</target>
         <note>Quick Actions drop down menu item for new search when widget enters edit mode and drop down menu expands</note>
       </trans-unit>
     </body>

--- a/bs/firefox-ios.xliff
+++ b/bs/firefox-ios.xliff
@@ -1,5 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 http://docs.oasis-open.org/xliff/v1.2/os/xliff-core-1.2-strict.xsd">
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?><xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 http://docs.oasis-open.org/xliff/v1.2/os/xliff-core-1.2-strict.xsd">
   <file original="Client/en.lproj/InfoPlist.strings" source-language="en" target-language="bs" datatype="plaintext">
     <header>
       <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="13.4.1" build-num="13F100"/>
@@ -189,7 +188,7 @@
       </trans-unit>
     </body>
   </file>
-  <file original="Shared/en.lproj/Default Browser.strings" source-language="en" target-language="bs" datatype="plaintext">
+  <file original="Shared/en.lproj/Default Browser.strings" datatype="plaintext" source-language="en" target-language="bs">
     <header>
       <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="13.4.1" build-num="13F100"/>
     </header>
@@ -3336,7 +3335,7 @@
       </trans-unit>
     </body>
   </file>
-  <file original="Shared/en.lproj/Today.strings" source-language="en" target-language="bs" datatype="plaintext">
+  <file original="Shared/en.lproj/Today.strings" datatype="plaintext" source-language="en" target-language="bs">
     <header>
       <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="13.4.1" build-num="13F100"/>
     </header>
@@ -3427,7 +3426,7 @@ Private Tab</source>
       </trans-unit>
     </body>
   </file>
-  <file original="Shared/Supporting Files/en.lproj/BookmarkPanel.strings" datatype="plaintext" source-language="en" target-language="bs">
+  <file original="Shared/Supporting Files/en.lproj/BookmarkPanel.strings" source-language="en" target-language="bs" datatype="plaintext">
     <header>
       <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="13.4.1" build-num="13F100"/>
     </header>
@@ -3495,66 +3494,82 @@ Private Tab</source>
     <body>
       <trans-unit id="2GqvPe" xml:space="preserve">
         <source>Go to Copied Link</source>
+        <target>Go to Copied Link</target>
         <note>Quick Actions drop down menu item for Go to Copied Link when widget enters edit mode and drop down menu expands</note>
       </trans-unit>
       <trans-unit id="PzSrmZ-2GqvPe" xml:space="preserve">
         <source>Just to confirm, you wanted ‘Go to Copied Link’?</source>
+        <target>Just to confirm, you wanted ‘Go to Copied Link’?</target>
         <note>Accessibility label to confirm the go to copied link selection</note>
       </trans-unit>
       <trans-unit id="PzSrmZ-eHmH1H" xml:space="preserve">
         <source>Just to confirm, you wanted ‘Clear Private Tabs’?</source>
+        <target>Just to confirm, you wanted ‘Clear Private Tabs’?</target>
         <note>Accessibility label to confirm the Clear Private Tabs selection</note>
       </trans-unit>
       <trans-unit id="PzSrmZ-scEmjs" xml:space="preserve">
         <source>Just to confirm, you wanted ‘New Private Search’?</source>
+        <target>Just to confirm, you wanted ‘New Private Search’?</target>
         <note>Accessibility label to confirm the New Private Search selection</note>
       </trans-unit>
       <trans-unit id="PzSrmZ-xRJbBP" xml:space="preserve">
         <source>Just to confirm, you wanted ‘New Search’?</source>
+        <target>Just to confirm, you wanted ‘New Search’?</target>
         <note>Accessibility label to confirm the New Search selection</note>
       </trans-unit>
       <trans-unit id="ctDNmu" xml:space="preserve">
         <source>Quick access to various Firefox actions</source>
+        <target>Quick access to various Firefox actions</target>
         <note>Description of the collection of widgets</note>
       </trans-unit>
       <trans-unit id="eHmH1H" xml:space="preserve">
         <source>Clear Private Tabs</source>
+        <target>Clear Private Tabs</target>
         <note>Quick Actions drop down menu item for lear Private Tabs when widget enters edit mode and drop down menu expands</note>
       </trans-unit>
       <trans-unit id="eV8mOT" xml:space="preserve">
         <source>Quick Action Type</source>
+        <target>Quick Action Type</target>
         <note>The description of a customizable section of the widget</note>
       </trans-unit>
       <trans-unit id="eqyNJg" xml:space="preserve">
         <source>Quick Action</source>
+        <target>Quick Action</target>
         <note>Title of the quick actions widgets</note>
       </trans-unit>
       <trans-unit id="fi3W24-2GqvPe" xml:space="preserve">
         <source>There are ${count} options matching ‘Go to Copied Link’.</source>
+        <target>There are ${count} options matching ‘Go to Copied Link’.</target>
         <note>Label showing how many widgets match ‘Go to Copied Link’. ${count} is a placeholder fo the number of widgets.</note>
       </trans-unit>
       <trans-unit id="fi3W24-eHmH1H" xml:space="preserve">
         <source>There are ${count} options matching ‘Clear Private Tabs’.</source>
+        <target>There are ${count} options matching ‘Clear Private Tabs’.</target>
         <note>Label showing how many widgets match ‘Clear Private Tabs’. ${count} is a placeholder fo the number of widgets.</note>
       </trans-unit>
       <trans-unit id="fi3W24-scEmjs" xml:space="preserve">
         <source>There are ${count} options matching ‘New Private Search’.</source>
+        <target>There are ${count} options matching ‘New Private Search’.</target>
         <note>Label showing how many widgets match ‘New Private Search’. ${count} is a placeholder fo the number of widgets.</note>
       </trans-unit>
       <trans-unit id="fi3W24-xRJbBP" xml:space="preserve">
         <source>There are ${count} options matching ‘New Search’.</source>
+        <target>There are ${count} options matching ‘New Search’.</target>
         <note>Label showing how many widgets match ‘New Search’. ${count} is a placeholder fo the number of widgets.</note>
       </trans-unit>
       <trans-unit id="scEmjs" xml:space="preserve">
         <source>New Private Search</source>
+        <target>New Private Search</target>
         <note>Quick Actions drop down menu item for new private search when widget enters edit mode and drop down menu expands</note>
       </trans-unit>
       <trans-unit id="w9jdPK" xml:space="preserve">
         <source>Quick Action</source>
+        <target>Quick Action</target>
         <note>Quick Actions left label text for dropdown menu when widget enters edit mode</note>
       </trans-unit>
       <trans-unit id="xRJbBP" xml:space="preserve">
         <source>New Search</source>
+        <target>New Search</target>
         <note>Quick Actions drop down menu item for new search when widget enters edit mode and drop down menu expands</note>
       </trans-unit>
     </body>

--- a/fa/firefox-ios.xliff
+++ b/fa/firefox-ios.xliff
@@ -1,5 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 http://docs.oasis-open.org/xliff/v1.2/os/xliff-core-1.2-strict.xsd">
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?><xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 http://docs.oasis-open.org/xliff/v1.2/os/xliff-core-1.2-strict.xsd">
   <file original="Client/en.lproj/InfoPlist.strings" source-language="en" target-language="fa" datatype="plaintext">
     <header>
       <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="13.4.1" build-num="13F100"/>
@@ -3608,7 +3607,7 @@ Private Tab</source>
       </trans-unit>
     </body>
   </file>
-  <file original="Shared/Supporting Files/en.lproj/BookmarkPanel.strings" datatype="plaintext" source-language="en" target-language="fa">
+  <file original="Shared/Supporting Files/en.lproj/BookmarkPanel.strings" source-language="en" target-language="fa" datatype="plaintext">
     <header>
       <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="13.4.1" build-num="13F100"/>
     </header>
@@ -3620,7 +3619,7 @@ Private Tab</source>
       </trans-unit>
     </body>
   </file>
-  <file original="Shared/Supporting Files/en.lproj/BookmarkPanelDeleteConfirm.strings" datatype="plaintext" source-language="en" target-language="fa">
+  <file original="Shared/Supporting Files/en.lproj/BookmarkPanelDeleteConfirm.strings" source-language="en" target-language="fa" datatype="plaintext">
     <header>
       <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="13.4.1" build-num="13F100"/>
     </header>
@@ -3680,71 +3679,87 @@ Private Tab</source>
     <body>
       <trans-unit id="2GqvPe" xml:space="preserve">
         <source>Go to Copied Link</source>
+        <target>Go to Copied Link</target>
         <note>Quick Actions drop down menu item for Go to Copied Link when widget enters edit mode and drop down menu expands</note>
       </trans-unit>
       <trans-unit id="PzSrmZ-2GqvPe" xml:space="preserve">
         <source>Just to confirm, you wanted ‘Go to Copied Link’?</source>
+        <target>Just to confirm, you wanted ‘Go to Copied Link’?</target>
         <note>Accessibility label to confirm the go to copied link selection</note>
       </trans-unit>
       <trans-unit id="PzSrmZ-eHmH1H" xml:space="preserve">
         <source>Just to confirm, you wanted ‘Clear Private Tabs’?</source>
+        <target>Just to confirm, you wanted ‘Clear Private Tabs’?</target>
         <note>Accessibility label to confirm the Clear Private Tabs selection</note>
       </trans-unit>
       <trans-unit id="PzSrmZ-scEmjs" xml:space="preserve">
         <source>Just to confirm, you wanted ‘New Private Search’?</source>
+        <target>Just to confirm, you wanted ‘New Private Search’?</target>
         <note>Accessibility label to confirm the New Private Search selection</note>
       </trans-unit>
       <trans-unit id="PzSrmZ-xRJbBP" xml:space="preserve">
         <source>Just to confirm, you wanted ‘New Search’?</source>
+        <target>Just to confirm, you wanted ‘New Search’?</target>
         <note>Accessibility label to confirm the New Search selection</note>
       </trans-unit>
       <trans-unit id="ctDNmu" xml:space="preserve">
         <source>Quick access to various Firefox actions</source>
+        <target>Quick access to various Firefox actions</target>
         <note>Description of the collection of widgets</note>
       </trans-unit>
       <trans-unit id="eHmH1H" xml:space="preserve">
         <source>Clear Private Tabs</source>
+        <target>Clear Private Tabs</target>
         <note>Quick Actions drop down menu item for lear Private Tabs when widget enters edit mode and drop down menu expands</note>
       </trans-unit>
       <trans-unit id="eV8mOT" xml:space="preserve">
         <source>Quick Action Type</source>
+        <target>Quick Action Type</target>
         <note>The description of a customizable section of the widget</note>
       </trans-unit>
       <trans-unit id="eqyNJg" xml:space="preserve">
         <source>Quick Action</source>
+        <target>Quick Action</target>
         <note>Title of the quick actions widgets</note>
       </trans-unit>
       <trans-unit id="fi3W24-2GqvPe" xml:space="preserve">
         <source>There are ${count} options matching ‘Go to Copied Link’.</source>
+        <target>There are ${count} options matching ‘Go to Copied Link’.</target>
         <note>Label showing how many widgets match ‘Go to Copied Link’. ${count} is a placeholder fo the number of widgets.</note>
       </trans-unit>
       <trans-unit id="fi3W24-eHmH1H" xml:space="preserve">
         <source>There are ${count} options matching ‘Clear Private Tabs’.</source>
+        <target>There are ${count} options matching ‘Clear Private Tabs’.</target>
         <note>Label showing how many widgets match ‘Clear Private Tabs’. ${count} is a placeholder fo the number of widgets.</note>
       </trans-unit>
       <trans-unit id="fi3W24-scEmjs" xml:space="preserve">
         <source>There are ${count} options matching ‘New Private Search’.</source>
+        <target>There are ${count} options matching ‘New Private Search’.</target>
         <note>Label showing how many widgets match ‘New Private Search’. ${count} is a placeholder fo the number of widgets.</note>
       </trans-unit>
       <trans-unit id="fi3W24-xRJbBP" xml:space="preserve">
         <source>There are ${count} options matching ‘New Search’.</source>
+        <target>There are ${count} options matching ‘New Search’.</target>
         <note>Label showing how many widgets match ‘New Search’. ${count} is a placeholder fo the number of widgets.</note>
       </trans-unit>
       <trans-unit id="scEmjs" xml:space="preserve">
         <source>New Private Search</source>
+        <target>New Private Search</target>
         <note>Quick Actions drop down menu item for new private search when widget enters edit mode and drop down menu expands</note>
       </trans-unit>
       <trans-unit id="w9jdPK" xml:space="preserve">
         <source>Quick Action</source>
+        <target>Quick Action</target>
         <note>Quick Actions left label text for dropdown menu when widget enters edit mode</note>
       </trans-unit>
       <trans-unit id="xRJbBP" xml:space="preserve">
         <source>New Search</source>
+        <target>New Search</target>
         <note>Quick Actions drop down menu item for new search when widget enters edit mode and drop down menu expands</note>
       </trans-unit>
     </body>
   </file>
-  <file original="WidgetKit/en.lproj/Localizable.strings" datatype="plaintext" source-language="en" target-language="fa">
+  <file original="WidgetKit/en.lproj/Localizable.strings" source-language="en" target-language="fa" datatype="plaintext">
     <header>
       <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="13.4.1" build-num="13F100"/>
     </header>

--- a/fi/firefox-ios.xliff
+++ b/fi/firefox-ios.xliff
@@ -1,5 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 http://docs.oasis-open.org/xliff/v1.2/os/xliff-core-1.2-strict.xsd">
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?><xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 http://docs.oasis-open.org/xliff/v1.2/os/xliff-core-1.2-strict.xsd">
   <file original="Client/en.lproj/InfoPlist.strings" source-language="en" target-language="fi" datatype="plaintext">
     <header>
       <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="13.4.1" build-num="13F100"/>
@@ -3646,7 +3645,7 @@ Private Tab</source>
       </trans-unit>
     </body>
   </file>
-  <file original="Shared/Supporting Files/en.lproj/BookmarkPanel.strings" datatype="plaintext" source-language="en" target-language="fi">
+  <file original="Shared/Supporting Files/en.lproj/BookmarkPanel.strings" source-language="en" target-language="fi" datatype="plaintext">
     <header>
       <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="13.4.1" build-num="13F100"/>
     </header>
@@ -3658,7 +3657,7 @@ Private Tab</source>
       </trans-unit>
     </body>
   </file>
-  <file original="Shared/Supporting Files/en.lproj/BookmarkPanelDeleteConfirm.strings" datatype="plaintext" source-language="en" target-language="fi">
+  <file original="Shared/Supporting Files/en.lproj/BookmarkPanelDeleteConfirm.strings" source-language="en" target-language="fi" datatype="plaintext">
     <header>
       <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="13.4.1" build-num="13F100"/>
     </header>
@@ -3721,67 +3720,82 @@ Private Tab</source>
       </trans-unit>
       <trans-unit id="PzSrmZ-2GqvPe" xml:space="preserve">
         <source>Just to confirm, you wanted ‘Go to Copied Link’?</source>
+        <target>Just to confirm, you wanted ‘Go to Copied Link’?</target>
         <note>Accessibility label to confirm the go to copied link selection</note>
       </trans-unit>
       <trans-unit id="PzSrmZ-eHmH1H" xml:space="preserve">
         <source>Just to confirm, you wanted ‘Clear Private Tabs’?</source>
+        <target>Just to confirm, you wanted ‘Clear Private Tabs’?</target>
         <note>Accessibility label to confirm the Clear Private Tabs selection</note>
       </trans-unit>
       <trans-unit id="PzSrmZ-scEmjs" xml:space="preserve">
         <source>Just to confirm, you wanted ‘New Private Search’?</source>
+        <target>Just to confirm, you wanted ‘New Private Search’?</target>
         <note>Accessibility label to confirm the New Private Search selection</note>
       </trans-unit>
       <trans-unit id="PzSrmZ-xRJbBP" xml:space="preserve">
         <source>Just to confirm, you wanted ‘New Search’?</source>
+        <target>Just to confirm, you wanted ‘New Search’?</target>
         <note>Accessibility label to confirm the New Search selection</note>
       </trans-unit>
       <trans-unit id="ctDNmu" xml:space="preserve">
         <source>Quick access to various Firefox actions</source>
+        <target>Quick access to various Firefox actions</target>
         <note>Description of the collection of widgets</note>
       </trans-unit>
       <trans-unit id="eHmH1H" xml:space="preserve">
         <source>Clear Private Tabs</source>
+        <target>Clear Private Tabs</target>
         <note>Quick Actions drop down menu item for lear Private Tabs when widget enters edit mode and drop down menu expands</note>
       </trans-unit>
       <trans-unit id="eV8mOT" xml:space="preserve">
         <source>Quick Action Type</source>
+        <target>Quick Action Type</target>
         <note>The description of a customizable section of the widget</note>
       </trans-unit>
       <trans-unit id="eqyNJg" xml:space="preserve">
         <source>Quick Action</source>
+        <target>Quick Action</target>
         <note>Title of the quick actions widgets</note>
       </trans-unit>
       <trans-unit id="fi3W24-2GqvPe" xml:space="preserve">
         <source>There are ${count} options matching ‘Go to Copied Link’.</source>
+        <target>There are ${count} options matching ‘Go to Copied Link’.</target>
         <note>Label showing how many widgets match ‘Go to Copied Link’. ${count} is a placeholder fo the number of widgets.</note>
       </trans-unit>
       <trans-unit id="fi3W24-eHmH1H" xml:space="preserve">
         <source>There are ${count} options matching ‘Clear Private Tabs’.</source>
+        <target>There are ${count} options matching ‘Clear Private Tabs’.</target>
         <note>Label showing how many widgets match ‘Clear Private Tabs’. ${count} is a placeholder fo the number of widgets.</note>
       </trans-unit>
       <trans-unit id="fi3W24-scEmjs" xml:space="preserve">
         <source>There are ${count} options matching ‘New Private Search’.</source>
+        <target>There are ${count} options matching ‘New Private Search’.</target>
         <note>Label showing how many widgets match ‘New Private Search’. ${count} is a placeholder fo the number of widgets.</note>
       </trans-unit>
       <trans-unit id="fi3W24-xRJbBP" xml:space="preserve">
         <source>There are ${count} options matching ‘New Search’.</source>
+        <target>There are ${count} options matching ‘New Search’.</target>
         <note>Label showing how many widgets match ‘New Search’. ${count} is a placeholder fo the number of widgets.</note>
       </trans-unit>
       <trans-unit id="scEmjs" xml:space="preserve">
         <source>New Private Search</source>
+        <target>New Private Search</target>
         <note>Quick Actions drop down menu item for new private search when widget enters edit mode and drop down menu expands</note>
       </trans-unit>
       <trans-unit id="w9jdPK" xml:space="preserve">
         <source>Quick Action</source>
+        <target>Quick Action</target>
         <note>Quick Actions left label text for dropdown menu when widget enters edit mode</note>
       </trans-unit>
       <trans-unit id="xRJbBP" xml:space="preserve">
         <source>New Search</source>
+        <target>New Search</target>
         <note>Quick Actions drop down menu item for new search when widget enters edit mode and drop down menu expands</note>
       </trans-unit>
     </body>
   </file>
-  <file original="WidgetKit/en.lproj/Localizable.strings" datatype="plaintext" source-language="en" target-language="fi">
+  <file original="WidgetKit/en.lproj/Localizable.strings" source-language="en" target-language="fi" datatype="plaintext">
     <header>
       <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="13.4.1" build-num="13F100"/>
     </header>

--- a/gl/firefox-ios.xliff
+++ b/gl/firefox-ios.xliff
@@ -1,5 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 http://docs.oasis-open.org/xliff/v1.2/os/xliff-core-1.2-strict.xsd">
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?><xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 http://docs.oasis-open.org/xliff/v1.2/os/xliff-core-1.2-strict.xsd">
   <file original="Client/en.lproj/InfoPlist.strings" source-language="en" target-language="gl" datatype="plaintext">
     <header>
       <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="13.4.1" build-num="13F100"/>
@@ -189,7 +188,7 @@
       </trans-unit>
     </body>
   </file>
-  <file original="Shared/en.lproj/Default Browser.strings" source-language="en" target-language="gl" datatype="plaintext">
+  <file original="Shared/en.lproj/Default Browser.strings" datatype="plaintext" source-language="en" target-language="gl">
     <header>
       <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="13.4.1" build-num="13F100"/>
     </header>
@@ -3346,7 +3345,7 @@
       </trans-unit>
     </body>
   </file>
-  <file original="Shared/en.lproj/Today.strings" source-language="en" target-language="gl" datatype="plaintext">
+  <file original="Shared/en.lproj/Today.strings" datatype="plaintext" source-language="en" target-language="gl">
     <header>
       <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="13.4.1" build-num="13F100"/>
     </header>
@@ -3437,7 +3436,7 @@ Private Tab</source>
       </trans-unit>
     </body>
   </file>
-  <file original="Shared/Supporting Files/en.lproj/BookmarkPanel.strings" datatype="plaintext" source-language="en" target-language="gl">
+  <file original="Shared/Supporting Files/en.lproj/BookmarkPanel.strings" source-language="en" target-language="gl" datatype="plaintext">
     <header>
       <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="13.4.1" build-num="13F100"/>
     </header>
@@ -3505,66 +3504,82 @@ Private Tab</source>
     <body>
       <trans-unit id="2GqvPe" xml:space="preserve">
         <source>Go to Copied Link</source>
+        <target>Go to Copied Link</target>
         <note>Quick Actions drop down menu item for Go to Copied Link when widget enters edit mode and drop down menu expands</note>
       </trans-unit>
       <trans-unit id="PzSrmZ-2GqvPe" xml:space="preserve">
         <source>Just to confirm, you wanted ‘Go to Copied Link’?</source>
+        <target>Just to confirm, you wanted ‘Go to Copied Link’?</target>
         <note>Accessibility label to confirm the go to copied link selection</note>
       </trans-unit>
       <trans-unit id="PzSrmZ-eHmH1H" xml:space="preserve">
         <source>Just to confirm, you wanted ‘Clear Private Tabs’?</source>
+        <target>Just to confirm, you wanted ‘Clear Private Tabs’?</target>
         <note>Accessibility label to confirm the Clear Private Tabs selection</note>
       </trans-unit>
       <trans-unit id="PzSrmZ-scEmjs" xml:space="preserve">
         <source>Just to confirm, you wanted ‘New Private Search’?</source>
+        <target>Just to confirm, you wanted ‘New Private Search’?</target>
         <note>Accessibility label to confirm the New Private Search selection</note>
       </trans-unit>
       <trans-unit id="PzSrmZ-xRJbBP" xml:space="preserve">
         <source>Just to confirm, you wanted ‘New Search’?</source>
+        <target>Just to confirm, you wanted ‘New Search’?</target>
         <note>Accessibility label to confirm the New Search selection</note>
       </trans-unit>
       <trans-unit id="ctDNmu" xml:space="preserve">
         <source>Quick access to various Firefox actions</source>
+        <target>Quick access to various Firefox actions</target>
         <note>Description of the collection of widgets</note>
       </trans-unit>
       <trans-unit id="eHmH1H" xml:space="preserve">
         <source>Clear Private Tabs</source>
+        <target>Clear Private Tabs</target>
         <note>Quick Actions drop down menu item for lear Private Tabs when widget enters edit mode and drop down menu expands</note>
       </trans-unit>
       <trans-unit id="eV8mOT" xml:space="preserve">
         <source>Quick Action Type</source>
+        <target>Quick Action Type</target>
         <note>The description of a customizable section of the widget</note>
       </trans-unit>
       <trans-unit id="eqyNJg" xml:space="preserve">
         <source>Quick Action</source>
+        <target>Quick Action</target>
         <note>Title of the quick actions widgets</note>
       </trans-unit>
       <trans-unit id="fi3W24-2GqvPe" xml:space="preserve">
         <source>There are ${count} options matching ‘Go to Copied Link’.</source>
+        <target>There are ${count} options matching ‘Go to Copied Link’.</target>
         <note>Label showing how many widgets match ‘Go to Copied Link’. ${count} is a placeholder fo the number of widgets.</note>
       </trans-unit>
       <trans-unit id="fi3W24-eHmH1H" xml:space="preserve">
         <source>There are ${count} options matching ‘Clear Private Tabs’.</source>
+        <target>There are ${count} options matching ‘Clear Private Tabs’.</target>
         <note>Label showing how many widgets match ‘Clear Private Tabs’. ${count} is a placeholder fo the number of widgets.</note>
       </trans-unit>
       <trans-unit id="fi3W24-scEmjs" xml:space="preserve">
         <source>There are ${count} options matching ‘New Private Search’.</source>
+        <target>There are ${count} options matching ‘New Private Search’.</target>
         <note>Label showing how many widgets match ‘New Private Search’. ${count} is a placeholder fo the number of widgets.</note>
       </trans-unit>
       <trans-unit id="fi3W24-xRJbBP" xml:space="preserve">
         <source>There are ${count} options matching ‘New Search’.</source>
+        <target>There are ${count} options matching ‘New Search’.</target>
         <note>Label showing how many widgets match ‘New Search’. ${count} is a placeholder fo the number of widgets.</note>
       </trans-unit>
       <trans-unit id="scEmjs" xml:space="preserve">
         <source>New Private Search</source>
+        <target>New Private Search</target>
         <note>Quick Actions drop down menu item for new private search when widget enters edit mode and drop down menu expands</note>
       </trans-unit>
       <trans-unit id="w9jdPK" xml:space="preserve">
         <source>Quick Action</source>
+        <target>Quick Action</target>
         <note>Quick Actions left label text for dropdown menu when widget enters edit mode</note>
       </trans-unit>
       <trans-unit id="xRJbBP" xml:space="preserve">
         <source>New Search</source>
+        <target>New Search</target>
         <note>Quick Actions drop down menu item for new search when widget enters edit mode and drop down menu expands</note>
       </trans-unit>
     </body>

--- a/gu-IN/firefox-ios.xliff
+++ b/gu-IN/firefox-ios.xliff
@@ -1,5 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 http://docs.oasis-open.org/xliff/v1.2/os/xliff-core-1.2-strict.xsd">
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?><xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 http://docs.oasis-open.org/xliff/v1.2/os/xliff-core-1.2-strict.xsd">
   <file original="Client/en.lproj/InfoPlist.strings" source-language="en" target-language="gu-IN" datatype="plaintext">
     <header>
       <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="13.4.1" build-num="13F100"/>
@@ -189,7 +188,7 @@
       </trans-unit>
     </body>
   </file>
-  <file original="Shared/en.lproj/Default Browser.strings" source-language="en" target-language="gu-IN" datatype="plaintext">
+  <file original="Shared/en.lproj/Default Browser.strings" datatype="plaintext" source-language="en" target-language="gu-IN">
     <header>
       <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="13.4.1" build-num="13F100"/>
     </header>
@@ -3436,7 +3435,7 @@
       </trans-unit>
     </body>
   </file>
-  <file original="Shared/en.lproj/Today.strings" source-language="en" target-language="gu-IN" datatype="plaintext">
+  <file original="Shared/en.lproj/Today.strings" datatype="plaintext" source-language="en" target-language="gu-IN">
     <header>
       <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="13.4.1" build-num="13F100"/>
     </header>
@@ -3527,7 +3526,7 @@ Private Tab</source>
       </trans-unit>
     </body>
   </file>
-  <file original="Shared/Supporting Files/en.lproj/BookmarkPanel.strings" datatype="plaintext" source-language="en" target-language="gu-IN">
+  <file original="Shared/Supporting Files/en.lproj/BookmarkPanel.strings" source-language="en" target-language="gu-IN" datatype="plaintext">
     <header>
       <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="13.4.1" build-num="13F100"/>
     </header>
@@ -3595,66 +3594,82 @@ Private Tab</source>
     <body>
       <trans-unit id="2GqvPe" xml:space="preserve">
         <source>Go to Copied Link</source>
+        <target>Go to Copied Link</target>
         <note>Quick Actions drop down menu item for Go to Copied Link when widget enters edit mode and drop down menu expands</note>
       </trans-unit>
       <trans-unit id="PzSrmZ-2GqvPe" xml:space="preserve">
         <source>Just to confirm, you wanted ‘Go to Copied Link’?</source>
+        <target>Just to confirm, you wanted ‘Go to Copied Link’?</target>
         <note>Accessibility label to confirm the go to copied link selection</note>
       </trans-unit>
       <trans-unit id="PzSrmZ-eHmH1H" xml:space="preserve">
         <source>Just to confirm, you wanted ‘Clear Private Tabs’?</source>
+        <target>Just to confirm, you wanted ‘Clear Private Tabs’?</target>
         <note>Accessibility label to confirm the Clear Private Tabs selection</note>
       </trans-unit>
       <trans-unit id="PzSrmZ-scEmjs" xml:space="preserve">
         <source>Just to confirm, you wanted ‘New Private Search’?</source>
+        <target>Just to confirm, you wanted ‘New Private Search’?</target>
         <note>Accessibility label to confirm the New Private Search selection</note>
       </trans-unit>
       <trans-unit id="PzSrmZ-xRJbBP" xml:space="preserve">
         <source>Just to confirm, you wanted ‘New Search’?</source>
+        <target>Just to confirm, you wanted ‘New Search’?</target>
         <note>Accessibility label to confirm the New Search selection</note>
       </trans-unit>
       <trans-unit id="ctDNmu" xml:space="preserve">
         <source>Quick access to various Firefox actions</source>
+        <target>Quick access to various Firefox actions</target>
         <note>Description of the collection of widgets</note>
       </trans-unit>
       <trans-unit id="eHmH1H" xml:space="preserve">
         <source>Clear Private Tabs</source>
+        <target>Clear Private Tabs</target>
         <note>Quick Actions drop down menu item for lear Private Tabs when widget enters edit mode and drop down menu expands</note>
       </trans-unit>
       <trans-unit id="eV8mOT" xml:space="preserve">
         <source>Quick Action Type</source>
+        <target>Quick Action Type</target>
         <note>The description of a customizable section of the widget</note>
       </trans-unit>
       <trans-unit id="eqyNJg" xml:space="preserve">
         <source>Quick Action</source>
+        <target>Quick Action</target>
         <note>Title of the quick actions widgets</note>
       </trans-unit>
       <trans-unit id="fi3W24-2GqvPe" xml:space="preserve">
         <source>There are ${count} options matching ‘Go to Copied Link’.</source>
+        <target>There are ${count} options matching ‘Go to Copied Link’.</target>
         <note>Label showing how many widgets match ‘Go to Copied Link’. ${count} is a placeholder fo the number of widgets.</note>
       </trans-unit>
       <trans-unit id="fi3W24-eHmH1H" xml:space="preserve">
         <source>There are ${count} options matching ‘Clear Private Tabs’.</source>
+        <target>There are ${count} options matching ‘Clear Private Tabs’.</target>
         <note>Label showing how many widgets match ‘Clear Private Tabs’. ${count} is a placeholder fo the number of widgets.</note>
       </trans-unit>
       <trans-unit id="fi3W24-scEmjs" xml:space="preserve">
         <source>There are ${count} options matching ‘New Private Search’.</source>
+        <target>There are ${count} options matching ‘New Private Search’.</target>
         <note>Label showing how many widgets match ‘New Private Search’. ${count} is a placeholder fo the number of widgets.</note>
       </trans-unit>
       <trans-unit id="fi3W24-xRJbBP" xml:space="preserve">
         <source>There are ${count} options matching ‘New Search’.</source>
+        <target>There are ${count} options matching ‘New Search’.</target>
         <note>Label showing how many widgets match ‘New Search’. ${count} is a placeholder fo the number of widgets.</note>
       </trans-unit>
       <trans-unit id="scEmjs" xml:space="preserve">
         <source>New Private Search</source>
+        <target>New Private Search</target>
         <note>Quick Actions drop down menu item for new private search when widget enters edit mode and drop down menu expands</note>
       </trans-unit>
       <trans-unit id="w9jdPK" xml:space="preserve">
         <source>Quick Action</source>
+        <target>Quick Action</target>
         <note>Quick Actions left label text for dropdown menu when widget enters edit mode</note>
       </trans-unit>
       <trans-unit id="xRJbBP" xml:space="preserve">
         <source>New Search</source>
+        <target>New Search</target>
         <note>Quick Actions drop down menu item for new search when widget enters edit mode and drop down menu expands</note>
       </trans-unit>
     </body>

--- a/hi-IN/firefox-ios.xliff
+++ b/hi-IN/firefox-ios.xliff
@@ -1,5 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 http://docs.oasis-open.org/xliff/v1.2/os/xliff-core-1.2-strict.xsd">
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?><xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 http://docs.oasis-open.org/xliff/v1.2/os/xliff-core-1.2-strict.xsd">
   <file original="Client/en.lproj/InfoPlist.strings" source-language="en" target-language="hi-IN" datatype="plaintext">
     <header>
       <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="13.4.1" build-num="13F100"/>
@@ -3656,7 +3655,7 @@ Private Tab</source>
       </trans-unit>
     </body>
   </file>
-  <file original="Shared/Supporting Files/en.lproj/BookmarkPanel.strings" datatype="plaintext" source-language="en" target-language="hi-IN">
+  <file original="Shared/Supporting Files/en.lproj/BookmarkPanel.strings" source-language="en" target-language="hi-IN" datatype="plaintext">
     <header>
       <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="13.4.1" build-num="13F100"/>
     </header>
@@ -3668,7 +3667,7 @@ Private Tab</source>
       </trans-unit>
     </body>
   </file>
-  <file original="Shared/Supporting Files/en.lproj/BookmarkPanelDeleteConfirm.strings" datatype="plaintext" source-language="en" target-language="hi-IN">
+  <file original="Shared/Supporting Files/en.lproj/BookmarkPanelDeleteConfirm.strings" source-language="en" target-language="hi-IN" datatype="plaintext">
     <header>
       <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="13.4.1" build-num="13F100"/>
     </header>
@@ -3733,22 +3732,27 @@ Private Tab</source>
       </trans-unit>
       <trans-unit id="PzSrmZ-2GqvPe" xml:space="preserve">
         <source>Just to confirm, you wanted ‘Go to Copied Link’?</source>
+        <target>Just to confirm, you wanted ‘Go to Copied Link’?</target>
         <note>Accessibility label to confirm the go to copied link selection</note>
       </trans-unit>
       <trans-unit id="PzSrmZ-eHmH1H" xml:space="preserve">
         <source>Just to confirm, you wanted ‘Clear Private Tabs’?</source>
+        <target>Just to confirm, you wanted ‘Clear Private Tabs’?</target>
         <note>Accessibility label to confirm the Clear Private Tabs selection</note>
       </trans-unit>
       <trans-unit id="PzSrmZ-scEmjs" xml:space="preserve">
         <source>Just to confirm, you wanted ‘New Private Search’?</source>
+        <target>Just to confirm, you wanted ‘New Private Search’?</target>
         <note>Accessibility label to confirm the New Private Search selection</note>
       </trans-unit>
       <trans-unit id="PzSrmZ-xRJbBP" xml:space="preserve">
         <source>Just to confirm, you wanted ‘New Search’?</source>
+        <target>Just to confirm, you wanted ‘New Search’?</target>
         <note>Accessibility label to confirm the New Search selection</note>
       </trans-unit>
       <trans-unit id="ctDNmu" xml:space="preserve">
         <source>Quick access to various Firefox actions</source>
+        <target>Quick access to various Firefox actions</target>
         <note>Description of the collection of widgets</note>
       </trans-unit>
       <trans-unit id="eHmH1H" xml:space="preserve">
@@ -3768,18 +3772,22 @@ Private Tab</source>
       </trans-unit>
       <trans-unit id="fi3W24-2GqvPe" xml:space="preserve">
         <source>There are ${count} options matching ‘Go to Copied Link’.</source>
+        <target>There are ${count} options matching ‘Go to Copied Link’.</target>
         <note>Label showing how many widgets match ‘Go to Copied Link’. ${count} is a placeholder fo the number of widgets.</note>
       </trans-unit>
       <trans-unit id="fi3W24-eHmH1H" xml:space="preserve">
         <source>There are ${count} options matching ‘Clear Private Tabs’.</source>
+        <target>There are ${count} options matching ‘Clear Private Tabs’.</target>
         <note>Label showing how many widgets match ‘Clear Private Tabs’. ${count} is a placeholder fo the number of widgets.</note>
       </trans-unit>
       <trans-unit id="fi3W24-scEmjs" xml:space="preserve">
         <source>There are ${count} options matching ‘New Private Search’.</source>
+        <target>There are ${count} options matching ‘New Private Search’.</target>
         <note>Label showing how many widgets match ‘New Private Search’. ${count} is a placeholder fo the number of widgets.</note>
       </trans-unit>
       <trans-unit id="fi3W24-xRJbBP" xml:space="preserve">
         <source>There are ${count} options matching ‘New Search’.</source>
+        <target>There are ${count} options matching ‘New Search’.</target>
         <note>Label showing how many widgets match ‘New Search’. ${count} is a placeholder fo the number of widgets.</note>
       </trans-unit>
       <trans-unit id="scEmjs" xml:space="preserve">
@@ -3799,7 +3807,7 @@ Private Tab</source>
       </trans-unit>
     </body>
   </file>
-  <file original="WidgetKit/en.lproj/Localizable.strings" datatype="plaintext" source-language="en" target-language="hi-IN">
+  <file original="WidgetKit/en.lproj/Localizable.strings" source-language="en" target-language="hi-IN" datatype="plaintext">
     <header>
       <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="13.4.1" build-num="13F100"/>
     </header>

--- a/jv/firefox-ios.xliff
+++ b/jv/firefox-ios.xliff
@@ -1,5 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 http://docs.oasis-open.org/xliff/v1.2/os/xliff-core-1.2-strict.xsd">
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?><xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 http://docs.oasis-open.org/xliff/v1.2/os/xliff-core-1.2-strict.xsd">
   <file original="Client/en.lproj/InfoPlist.strings" source-language="en" target-language="jv" datatype="plaintext">
     <header>
       <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="13.4.1" build-num="13F100"/>
@@ -188,7 +187,7 @@
       </trans-unit>
     </body>
   </file>
-  <file original="Shared/en.lproj/Default Browser.strings" source-language="en" target-language="jv" datatype="plaintext">
+  <file original="Shared/en.lproj/Default Browser.strings" datatype="plaintext" source-language="en" target-language="jv">
     <header>
       <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="13.4.1" build-num="13F100"/>
     </header>
@@ -287,7 +286,7 @@
       </trans-unit>
     </body>
   </file>
-  <file original="Shared/en.lproj/Intro.strings" source-language="en" target-language="jv" datatype="plaintext">
+  <file original="Shared/en.lproj/Intro.strings" datatype="plaintext" source-language="en" target-language="jv">
     <header>
       <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="13.4.1" build-num="13F100"/>
     </header>
@@ -3263,7 +3262,7 @@
       </trans-unit>
     </body>
   </file>
-  <file original="Shared/en.lproj/Shared.strings" source-language="en" target-language="jv" datatype="plaintext">
+  <file original="Shared/en.lproj/Shared.strings" datatype="plaintext" source-language="en" target-language="jv">
     <header>
       <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="13.4.1" build-num="13F100"/>
     </header>
@@ -3298,7 +3297,7 @@
       </trans-unit>
     </body>
   </file>
-  <file original="Shared/en.lproj/Today.strings" source-language="en" target-language="jv" datatype="plaintext">
+  <file original="Shared/en.lproj/Today.strings" datatype="plaintext" source-language="en" target-language="jv">
     <header>
       <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="13.4.1" build-num="13F100"/>
     </header>
@@ -3389,7 +3388,7 @@ Private Tab</source>
       </trans-unit>
     </body>
   </file>
-  <file original="Shared/Supporting Files/en.lproj/BookmarkPanel.strings" datatype="plaintext" source-language="en" target-language="jv">
+  <file original="Shared/Supporting Files/en.lproj/BookmarkPanel.strings" source-language="en" target-language="jv" datatype="plaintext">
     <header>
       <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="13.4.1" build-num="13F100"/>
     </header>
@@ -3457,66 +3456,82 @@ Private Tab</source>
     <body>
       <trans-unit id="2GqvPe" xml:space="preserve">
         <source>Go to Copied Link</source>
+        <target>Go to Copied Link</target>
         <note>Quick Actions drop down menu item for Go to Copied Link when widget enters edit mode and drop down menu expands</note>
       </trans-unit>
       <trans-unit id="PzSrmZ-2GqvPe" xml:space="preserve">
         <source>Just to confirm, you wanted ‘Go to Copied Link’?</source>
+        <target>Just to confirm, you wanted ‘Go to Copied Link’?</target>
         <note>Accessibility label to confirm the go to copied link selection</note>
       </trans-unit>
       <trans-unit id="PzSrmZ-eHmH1H" xml:space="preserve">
         <source>Just to confirm, you wanted ‘Clear Private Tabs’?</source>
+        <target>Just to confirm, you wanted ‘Clear Private Tabs’?</target>
         <note>Accessibility label to confirm the Clear Private Tabs selection</note>
       </trans-unit>
       <trans-unit id="PzSrmZ-scEmjs" xml:space="preserve">
         <source>Just to confirm, you wanted ‘New Private Search’?</source>
+        <target>Just to confirm, you wanted ‘New Private Search’?</target>
         <note>Accessibility label to confirm the New Private Search selection</note>
       </trans-unit>
       <trans-unit id="PzSrmZ-xRJbBP" xml:space="preserve">
         <source>Just to confirm, you wanted ‘New Search’?</source>
+        <target>Just to confirm, you wanted ‘New Search’?</target>
         <note>Accessibility label to confirm the New Search selection</note>
       </trans-unit>
       <trans-unit id="ctDNmu" xml:space="preserve">
         <source>Quick access to various Firefox actions</source>
+        <target>Quick access to various Firefox actions</target>
         <note>Description of the collection of widgets</note>
       </trans-unit>
       <trans-unit id="eHmH1H" xml:space="preserve">
         <source>Clear Private Tabs</source>
+        <target>Clear Private Tabs</target>
         <note>Quick Actions drop down menu item for lear Private Tabs when widget enters edit mode and drop down menu expands</note>
       </trans-unit>
       <trans-unit id="eV8mOT" xml:space="preserve">
         <source>Quick Action Type</source>
+        <target>Quick Action Type</target>
         <note>The description of a customizable section of the widget</note>
       </trans-unit>
       <trans-unit id="eqyNJg" xml:space="preserve">
         <source>Quick Action</source>
+        <target>Quick Action</target>
         <note>Title of the quick actions widgets</note>
       </trans-unit>
       <trans-unit id="fi3W24-2GqvPe" xml:space="preserve">
         <source>There are ${count} options matching ‘Go to Copied Link’.</source>
+        <target>There are ${count} options matching ‘Go to Copied Link’.</target>
         <note>Label showing how many widgets match ‘Go to Copied Link’. ${count} is a placeholder fo the number of widgets.</note>
       </trans-unit>
       <trans-unit id="fi3W24-eHmH1H" xml:space="preserve">
         <source>There are ${count} options matching ‘Clear Private Tabs’.</source>
+        <target>There are ${count} options matching ‘Clear Private Tabs’.</target>
         <note>Label showing how many widgets match ‘Clear Private Tabs’. ${count} is a placeholder fo the number of widgets.</note>
       </trans-unit>
       <trans-unit id="fi3W24-scEmjs" xml:space="preserve">
         <source>There are ${count} options matching ‘New Private Search’.</source>
+        <target>There are ${count} options matching ‘New Private Search’.</target>
         <note>Label showing how many widgets match ‘New Private Search’. ${count} is a placeholder fo the number of widgets.</note>
       </trans-unit>
       <trans-unit id="fi3W24-xRJbBP" xml:space="preserve">
         <source>There are ${count} options matching ‘New Search’.</source>
+        <target>There are ${count} options matching ‘New Search’.</target>
         <note>Label showing how many widgets match ‘New Search’. ${count} is a placeholder fo the number of widgets.</note>
       </trans-unit>
       <trans-unit id="scEmjs" xml:space="preserve">
         <source>New Private Search</source>
+        <target>New Private Search</target>
         <note>Quick Actions drop down menu item for new private search when widget enters edit mode and drop down menu expands</note>
       </trans-unit>
       <trans-unit id="w9jdPK" xml:space="preserve">
         <source>Quick Action</source>
+        <target>Quick Action</target>
         <note>Quick Actions left label text for dropdown menu when widget enters edit mode</note>
       </trans-unit>
       <trans-unit id="xRJbBP" xml:space="preserve">
         <source>New Search</source>
+        <target>New Search</target>
         <note>Quick Actions drop down menu item for new search when widget enters edit mode and drop down menu expands</note>
       </trans-unit>
     </body>

--- a/km/firefox-ios.xliff
+++ b/km/firefox-ios.xliff
@@ -1,5 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 http://docs.oasis-open.org/xliff/v1.2/os/xliff-core-1.2-strict.xsd">
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?><xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 http://docs.oasis-open.org/xliff/v1.2/os/xliff-core-1.2-strict.xsd">
   <file original="Client/en.lproj/InfoPlist.strings" source-language="en" target-language="km" datatype="plaintext">
     <header>
       <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="13.4.1" build-num="13F100"/>
@@ -3486,7 +3485,7 @@
       </trans-unit>
     </body>
   </file>
-  <file original="Shared/en.lproj/Today.strings" source-language="en" target-language="km" datatype="plaintext">
+  <file original="Shared/en.lproj/Today.strings" datatype="plaintext" source-language="en" target-language="km">
     <header>
       <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="13.4.1" build-num="13F100"/>
     </header>
@@ -3577,7 +3576,7 @@ Private Tab</source>
       </trans-unit>
     </body>
   </file>
-  <file original="Shared/Supporting Files/en.lproj/BookmarkPanel.strings" datatype="plaintext" source-language="en" target-language="km">
+  <file original="Shared/Supporting Files/en.lproj/BookmarkPanel.strings" source-language="en" target-language="km" datatype="plaintext">
     <header>
       <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="13.4.1" build-num="13F100"/>
     </header>
@@ -3589,7 +3588,7 @@ Private Tab</source>
       </trans-unit>
     </body>
   </file>
-  <file original="Shared/Supporting Files/en.lproj/BookmarkPanelDeleteConfirm.strings" datatype="plaintext" source-language="en" target-language="km">
+  <file original="Shared/Supporting Files/en.lproj/BookmarkPanelDeleteConfirm.strings" source-language="en" target-language="km" datatype="plaintext">
     <header>
       <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="13.4.1" build-num="13F100"/>
     </header>
@@ -3649,66 +3648,82 @@ Private Tab</source>
     <body>
       <trans-unit id="2GqvPe" xml:space="preserve">
         <source>Go to Copied Link</source>
+        <target>Go to Copied Link</target>
         <note>Quick Actions drop down menu item for Go to Copied Link when widget enters edit mode and drop down menu expands</note>
       </trans-unit>
       <trans-unit id="PzSrmZ-2GqvPe" xml:space="preserve">
         <source>Just to confirm, you wanted ‘Go to Copied Link’?</source>
+        <target>Just to confirm, you wanted ‘Go to Copied Link’?</target>
         <note>Accessibility label to confirm the go to copied link selection</note>
       </trans-unit>
       <trans-unit id="PzSrmZ-eHmH1H" xml:space="preserve">
         <source>Just to confirm, you wanted ‘Clear Private Tabs’?</source>
+        <target>Just to confirm, you wanted ‘Clear Private Tabs’?</target>
         <note>Accessibility label to confirm the Clear Private Tabs selection</note>
       </trans-unit>
       <trans-unit id="PzSrmZ-scEmjs" xml:space="preserve">
         <source>Just to confirm, you wanted ‘New Private Search’?</source>
+        <target>Just to confirm, you wanted ‘New Private Search’?</target>
         <note>Accessibility label to confirm the New Private Search selection</note>
       </trans-unit>
       <trans-unit id="PzSrmZ-xRJbBP" xml:space="preserve">
         <source>Just to confirm, you wanted ‘New Search’?</source>
+        <target>Just to confirm, you wanted ‘New Search’?</target>
         <note>Accessibility label to confirm the New Search selection</note>
       </trans-unit>
       <trans-unit id="ctDNmu" xml:space="preserve">
         <source>Quick access to various Firefox actions</source>
+        <target>Quick access to various Firefox actions</target>
         <note>Description of the collection of widgets</note>
       </trans-unit>
       <trans-unit id="eHmH1H" xml:space="preserve">
         <source>Clear Private Tabs</source>
+        <target>Clear Private Tabs</target>
         <note>Quick Actions drop down menu item for lear Private Tabs when widget enters edit mode and drop down menu expands</note>
       </trans-unit>
       <trans-unit id="eV8mOT" xml:space="preserve">
         <source>Quick Action Type</source>
+        <target>Quick Action Type</target>
         <note>The description of a customizable section of the widget</note>
       </trans-unit>
       <trans-unit id="eqyNJg" xml:space="preserve">
         <source>Quick Action</source>
+        <target>Quick Action</target>
         <note>Title of the quick actions widgets</note>
       </trans-unit>
       <trans-unit id="fi3W24-2GqvPe" xml:space="preserve">
         <source>There are ${count} options matching ‘Go to Copied Link’.</source>
+        <target>There are ${count} options matching ‘Go to Copied Link’.</target>
         <note>Label showing how many widgets match ‘Go to Copied Link’. ${count} is a placeholder fo the number of widgets.</note>
       </trans-unit>
       <trans-unit id="fi3W24-eHmH1H" xml:space="preserve">
         <source>There are ${count} options matching ‘Clear Private Tabs’.</source>
+        <target>There are ${count} options matching ‘Clear Private Tabs’.</target>
         <note>Label showing how many widgets match ‘Clear Private Tabs’. ${count} is a placeholder fo the number of widgets.</note>
       </trans-unit>
       <trans-unit id="fi3W24-scEmjs" xml:space="preserve">
         <source>There are ${count} options matching ‘New Private Search’.</source>
+        <target>There are ${count} options matching ‘New Private Search’.</target>
         <note>Label showing how many widgets match ‘New Private Search’. ${count} is a placeholder fo the number of widgets.</note>
       </trans-unit>
       <trans-unit id="fi3W24-xRJbBP" xml:space="preserve">
         <source>There are ${count} options matching ‘New Search’.</source>
+        <target>There are ${count} options matching ‘New Search’.</target>
         <note>Label showing how many widgets match ‘New Search’. ${count} is a placeholder fo the number of widgets.</note>
       </trans-unit>
       <trans-unit id="scEmjs" xml:space="preserve">
         <source>New Private Search</source>
+        <target>New Private Search</target>
         <note>Quick Actions drop down menu item for new private search when widget enters edit mode and drop down menu expands</note>
       </trans-unit>
       <trans-unit id="w9jdPK" xml:space="preserve">
         <source>Quick Action</source>
+        <target>Quick Action</target>
         <note>Quick Actions left label text for dropdown menu when widget enters edit mode</note>
       </trans-unit>
       <trans-unit id="xRJbBP" xml:space="preserve">
         <source>New Search</source>
+        <target>New Search</target>
         <note>Quick Actions drop down menu item for new search when widget enters edit mode and drop down menu expands</note>
       </trans-unit>
     </body>

--- a/kn/firefox-ios.xliff
+++ b/kn/firefox-ios.xliff
@@ -1,5 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 http://docs.oasis-open.org/xliff/v1.2/os/xliff-core-1.2-strict.xsd">
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?><xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 http://docs.oasis-open.org/xliff/v1.2/os/xliff-core-1.2-strict.xsd">
   <file original="Client/en.lproj/InfoPlist.strings" source-language="en" target-language="kn" datatype="plaintext">
     <header>
       <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="13.4.1" build-num="13F100"/>
@@ -187,7 +186,7 @@
       </trans-unit>
     </body>
   </file>
-  <file original="Shared/en.lproj/Default Browser.strings" source-language="en" target-language="kn" datatype="plaintext">
+  <file original="Shared/en.lproj/Default Browser.strings" datatype="plaintext" source-language="en" target-language="kn">
     <header>
       <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="13.4.1" build-num="13F100"/>
     </header>
@@ -3414,7 +3413,7 @@ Private Tab</source>
       </trans-unit>
     </body>
   </file>
-  <file original="Shared/Supporting Files/en.lproj/BookmarkPanel.strings" datatype="plaintext" source-language="en" target-language="kn">
+  <file original="Shared/Supporting Files/en.lproj/BookmarkPanel.strings" source-language="en" target-language="kn" datatype="plaintext">
     <header>
       <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="13.4.1" build-num="13F100"/>
     </header>
@@ -3482,66 +3481,82 @@ Private Tab</source>
     <body>
       <trans-unit id="2GqvPe" xml:space="preserve">
         <source>Go to Copied Link</source>
+        <target>Go to Copied Link</target>
         <note>Quick Actions drop down menu item for Go to Copied Link when widget enters edit mode and drop down menu expands</note>
       </trans-unit>
       <trans-unit id="PzSrmZ-2GqvPe" xml:space="preserve">
         <source>Just to confirm, you wanted ‘Go to Copied Link’?</source>
+        <target>Just to confirm, you wanted ‘Go to Copied Link’?</target>
         <note>Accessibility label to confirm the go to copied link selection</note>
       </trans-unit>
       <trans-unit id="PzSrmZ-eHmH1H" xml:space="preserve">
         <source>Just to confirm, you wanted ‘Clear Private Tabs’?</source>
+        <target>Just to confirm, you wanted ‘Clear Private Tabs’?</target>
         <note>Accessibility label to confirm the Clear Private Tabs selection</note>
       </trans-unit>
       <trans-unit id="PzSrmZ-scEmjs" xml:space="preserve">
         <source>Just to confirm, you wanted ‘New Private Search’?</source>
+        <target>Just to confirm, you wanted ‘New Private Search’?</target>
         <note>Accessibility label to confirm the New Private Search selection</note>
       </trans-unit>
       <trans-unit id="PzSrmZ-xRJbBP" xml:space="preserve">
         <source>Just to confirm, you wanted ‘New Search’?</source>
+        <target>Just to confirm, you wanted ‘New Search’?</target>
         <note>Accessibility label to confirm the New Search selection</note>
       </trans-unit>
       <trans-unit id="ctDNmu" xml:space="preserve">
         <source>Quick access to various Firefox actions</source>
+        <target>Quick access to various Firefox actions</target>
         <note>Description of the collection of widgets</note>
       </trans-unit>
       <trans-unit id="eHmH1H" xml:space="preserve">
         <source>Clear Private Tabs</source>
+        <target>Clear Private Tabs</target>
         <note>Quick Actions drop down menu item for lear Private Tabs when widget enters edit mode and drop down menu expands</note>
       </trans-unit>
       <trans-unit id="eV8mOT" xml:space="preserve">
         <source>Quick Action Type</source>
+        <target>Quick Action Type</target>
         <note>The description of a customizable section of the widget</note>
       </trans-unit>
       <trans-unit id="eqyNJg" xml:space="preserve">
         <source>Quick Action</source>
+        <target>Quick Action</target>
         <note>Title of the quick actions widgets</note>
       </trans-unit>
       <trans-unit id="fi3W24-2GqvPe" xml:space="preserve">
         <source>There are ${count} options matching ‘Go to Copied Link’.</source>
+        <target>There are ${count} options matching ‘Go to Copied Link’.</target>
         <note>Label showing how many widgets match ‘Go to Copied Link’. ${count} is a placeholder fo the number of widgets.</note>
       </trans-unit>
       <trans-unit id="fi3W24-eHmH1H" xml:space="preserve">
         <source>There are ${count} options matching ‘Clear Private Tabs’.</source>
+        <target>There are ${count} options matching ‘Clear Private Tabs’.</target>
         <note>Label showing how many widgets match ‘Clear Private Tabs’. ${count} is a placeholder fo the number of widgets.</note>
       </trans-unit>
       <trans-unit id="fi3W24-scEmjs" xml:space="preserve">
         <source>There are ${count} options matching ‘New Private Search’.</source>
+        <target>There are ${count} options matching ‘New Private Search’.</target>
         <note>Label showing how many widgets match ‘New Private Search’. ${count} is a placeholder fo the number of widgets.</note>
       </trans-unit>
       <trans-unit id="fi3W24-xRJbBP" xml:space="preserve">
         <source>There are ${count} options matching ‘New Search’.</source>
+        <target>There are ${count} options matching ‘New Search’.</target>
         <note>Label showing how many widgets match ‘New Search’. ${count} is a placeholder fo the number of widgets.</note>
       </trans-unit>
       <trans-unit id="scEmjs" xml:space="preserve">
         <source>New Private Search</source>
+        <target>New Private Search</target>
         <note>Quick Actions drop down menu item for new private search when widget enters edit mode and drop down menu expands</note>
       </trans-unit>
       <trans-unit id="w9jdPK" xml:space="preserve">
         <source>Quick Action</source>
+        <target>Quick Action</target>
         <note>Quick Actions left label text for dropdown menu when widget enters edit mode</note>
       </trans-unit>
       <trans-unit id="xRJbBP" xml:space="preserve">
         <source>New Search</source>
+        <target>New Search</target>
         <note>Quick Actions drop down menu item for new search when widget enters edit mode and drop down menu expands</note>
       </trans-unit>
     </body>

--- a/lv/firefox-ios.xliff
+++ b/lv/firefox-ios.xliff
@@ -1,5 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 http://docs.oasis-open.org/xliff/v1.2/os/xliff-core-1.2-strict.xsd">
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?><xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 http://docs.oasis-open.org/xliff/v1.2/os/xliff-core-1.2-strict.xsd">
   <file original="Client/en.lproj/InfoPlist.strings" source-language="en" target-language="lv" datatype="plaintext">
     <header>
       <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="13.4.1" build-num="13F100"/>
@@ -189,7 +188,7 @@
       </trans-unit>
     </body>
   </file>
-  <file original="Shared/en.lproj/Default Browser.strings" source-language="en" target-language="lv" datatype="plaintext">
+  <file original="Shared/en.lproj/Default Browser.strings" datatype="plaintext" source-language="en" target-language="lv">
     <header>
       <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="13.4.1" build-num="13F100"/>
     </header>
@@ -3365,7 +3364,7 @@
       </trans-unit>
     </body>
   </file>
-  <file original="Shared/en.lproj/Today.strings" source-language="en" target-language="lv" datatype="plaintext">
+  <file original="Shared/en.lproj/Today.strings" datatype="plaintext" source-language="en" target-language="lv">
     <header>
       <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="13.4.1" build-num="13F100"/>
     </header>
@@ -3456,7 +3455,7 @@ Private Tab</source>
       </trans-unit>
     </body>
   </file>
-  <file original="Shared/Supporting Files/en.lproj/BookmarkPanel.strings" datatype="plaintext" source-language="en" target-language="lv">
+  <file original="Shared/Supporting Files/en.lproj/BookmarkPanel.strings" source-language="en" target-language="lv" datatype="plaintext">
     <header>
       <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="13.4.1" build-num="13F100"/>
     </header>
@@ -3524,66 +3523,82 @@ Private Tab</source>
     <body>
       <trans-unit id="2GqvPe" xml:space="preserve">
         <source>Go to Copied Link</source>
+        <target>Go to Copied Link</target>
         <note>Quick Actions drop down menu item for Go to Copied Link when widget enters edit mode and drop down menu expands</note>
       </trans-unit>
       <trans-unit id="PzSrmZ-2GqvPe" xml:space="preserve">
         <source>Just to confirm, you wanted ‘Go to Copied Link’?</source>
+        <target>Just to confirm, you wanted ‘Go to Copied Link’?</target>
         <note>Accessibility label to confirm the go to copied link selection</note>
       </trans-unit>
       <trans-unit id="PzSrmZ-eHmH1H" xml:space="preserve">
         <source>Just to confirm, you wanted ‘Clear Private Tabs’?</source>
+        <target>Just to confirm, you wanted ‘Clear Private Tabs’?</target>
         <note>Accessibility label to confirm the Clear Private Tabs selection</note>
       </trans-unit>
       <trans-unit id="PzSrmZ-scEmjs" xml:space="preserve">
         <source>Just to confirm, you wanted ‘New Private Search’?</source>
+        <target>Just to confirm, you wanted ‘New Private Search’?</target>
         <note>Accessibility label to confirm the New Private Search selection</note>
       </trans-unit>
       <trans-unit id="PzSrmZ-xRJbBP" xml:space="preserve">
         <source>Just to confirm, you wanted ‘New Search’?</source>
+        <target>Just to confirm, you wanted ‘New Search’?</target>
         <note>Accessibility label to confirm the New Search selection</note>
       </trans-unit>
       <trans-unit id="ctDNmu" xml:space="preserve">
         <source>Quick access to various Firefox actions</source>
+        <target>Quick access to various Firefox actions</target>
         <note>Description of the collection of widgets</note>
       </trans-unit>
       <trans-unit id="eHmH1H" xml:space="preserve">
         <source>Clear Private Tabs</source>
+        <target>Clear Private Tabs</target>
         <note>Quick Actions drop down menu item for lear Private Tabs when widget enters edit mode and drop down menu expands</note>
       </trans-unit>
       <trans-unit id="eV8mOT" xml:space="preserve">
         <source>Quick Action Type</source>
+        <target>Quick Action Type</target>
         <note>The description of a customizable section of the widget</note>
       </trans-unit>
       <trans-unit id="eqyNJg" xml:space="preserve">
         <source>Quick Action</source>
+        <target>Quick Action</target>
         <note>Title of the quick actions widgets</note>
       </trans-unit>
       <trans-unit id="fi3W24-2GqvPe" xml:space="preserve">
         <source>There are ${count} options matching ‘Go to Copied Link’.</source>
+        <target>There are ${count} options matching ‘Go to Copied Link’.</target>
         <note>Label showing how many widgets match ‘Go to Copied Link’. ${count} is a placeholder fo the number of widgets.</note>
       </trans-unit>
       <trans-unit id="fi3W24-eHmH1H" xml:space="preserve">
         <source>There are ${count} options matching ‘Clear Private Tabs’.</source>
+        <target>There are ${count} options matching ‘Clear Private Tabs’.</target>
         <note>Label showing how many widgets match ‘Clear Private Tabs’. ${count} is a placeholder fo the number of widgets.</note>
       </trans-unit>
       <trans-unit id="fi3W24-scEmjs" xml:space="preserve">
         <source>There are ${count} options matching ‘New Private Search’.</source>
+        <target>There are ${count} options matching ‘New Private Search’.</target>
         <note>Label showing how many widgets match ‘New Private Search’. ${count} is a placeholder fo the number of widgets.</note>
       </trans-unit>
       <trans-unit id="fi3W24-xRJbBP" xml:space="preserve">
         <source>There are ${count} options matching ‘New Search’.</source>
+        <target>There are ${count} options matching ‘New Search’.</target>
         <note>Label showing how many widgets match ‘New Search’. ${count} is a placeholder fo the number of widgets.</note>
       </trans-unit>
       <trans-unit id="scEmjs" xml:space="preserve">
         <source>New Private Search</source>
+        <target>New Private Search</target>
         <note>Quick Actions drop down menu item for new private search when widget enters edit mode and drop down menu expands</note>
       </trans-unit>
       <trans-unit id="w9jdPK" xml:space="preserve">
         <source>Quick Action</source>
+        <target>Quick Action</target>
         <note>Quick Actions left label text for dropdown menu when widget enters edit mode</note>
       </trans-unit>
       <trans-unit id="xRJbBP" xml:space="preserve">
         <source>New Search</source>
+        <target>New Search</target>
         <note>Quick Actions drop down menu item for new search when widget enters edit mode and drop down menu expands</note>
       </trans-unit>
     </body>

--- a/ml/firefox-ios.xliff
+++ b/ml/firefox-ios.xliff
@@ -1,5 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 http://docs.oasis-open.org/xliff/v1.2/os/xliff-core-1.2-strict.xsd">
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?><xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 http://docs.oasis-open.org/xliff/v1.2/os/xliff-core-1.2-strict.xsd">
   <file original="Client/en.lproj/InfoPlist.strings" source-language="en" target-language="ml" datatype="plaintext">
     <header>
       <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="13.4.1" build-num="13F100"/>
@@ -189,7 +188,7 @@
       </trans-unit>
     </body>
   </file>
-  <file original="Shared/en.lproj/Default Browser.strings" source-language="en" target-language="ml" datatype="plaintext">
+  <file original="Shared/en.lproj/Default Browser.strings" datatype="plaintext" source-language="en" target-language="ml">
     <header>
       <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="13.4.1" build-num="13F100"/>
     </header>
@@ -3430,7 +3429,7 @@
       </trans-unit>
     </body>
   </file>
-  <file original="Shared/en.lproj/Today.strings" source-language="en" target-language="ml" datatype="plaintext">
+  <file original="Shared/en.lproj/Today.strings" datatype="plaintext" source-language="en" target-language="ml">
     <header>
       <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="13.4.1" build-num="13F100"/>
     </header>
@@ -3521,7 +3520,7 @@ Private Tab</source>
       </trans-unit>
     </body>
   </file>
-  <file original="Shared/Supporting Files/en.lproj/BookmarkPanel.strings" datatype="plaintext" source-language="en" target-language="ml">
+  <file original="Shared/Supporting Files/en.lproj/BookmarkPanel.strings" source-language="en" target-language="ml" datatype="plaintext">
     <header>
       <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="13.4.1" build-num="13F100"/>
     </header>
@@ -3589,66 +3588,82 @@ Private Tab</source>
     <body>
       <trans-unit id="2GqvPe" xml:space="preserve">
         <source>Go to Copied Link</source>
+        <target>Go to Copied Link</target>
         <note>Quick Actions drop down menu item for Go to Copied Link when widget enters edit mode and drop down menu expands</note>
       </trans-unit>
       <trans-unit id="PzSrmZ-2GqvPe" xml:space="preserve">
         <source>Just to confirm, you wanted ‘Go to Copied Link’?</source>
+        <target>Just to confirm, you wanted ‘Go to Copied Link’?</target>
         <note>Accessibility label to confirm the go to copied link selection</note>
       </trans-unit>
       <trans-unit id="PzSrmZ-eHmH1H" xml:space="preserve">
         <source>Just to confirm, you wanted ‘Clear Private Tabs’?</source>
+        <target>Just to confirm, you wanted ‘Clear Private Tabs’?</target>
         <note>Accessibility label to confirm the Clear Private Tabs selection</note>
       </trans-unit>
       <trans-unit id="PzSrmZ-scEmjs" xml:space="preserve">
         <source>Just to confirm, you wanted ‘New Private Search’?</source>
+        <target>Just to confirm, you wanted ‘New Private Search’?</target>
         <note>Accessibility label to confirm the New Private Search selection</note>
       </trans-unit>
       <trans-unit id="PzSrmZ-xRJbBP" xml:space="preserve">
         <source>Just to confirm, you wanted ‘New Search’?</source>
+        <target>Just to confirm, you wanted ‘New Search’?</target>
         <note>Accessibility label to confirm the New Search selection</note>
       </trans-unit>
       <trans-unit id="ctDNmu" xml:space="preserve">
         <source>Quick access to various Firefox actions</source>
+        <target>Quick access to various Firefox actions</target>
         <note>Description of the collection of widgets</note>
       </trans-unit>
       <trans-unit id="eHmH1H" xml:space="preserve">
         <source>Clear Private Tabs</source>
+        <target>Clear Private Tabs</target>
         <note>Quick Actions drop down menu item for lear Private Tabs when widget enters edit mode and drop down menu expands</note>
       </trans-unit>
       <trans-unit id="eV8mOT" xml:space="preserve">
         <source>Quick Action Type</source>
+        <target>Quick Action Type</target>
         <note>The description of a customizable section of the widget</note>
       </trans-unit>
       <trans-unit id="eqyNJg" xml:space="preserve">
         <source>Quick Action</source>
+        <target>Quick Action</target>
         <note>Title of the quick actions widgets</note>
       </trans-unit>
       <trans-unit id="fi3W24-2GqvPe" xml:space="preserve">
         <source>There are ${count} options matching ‘Go to Copied Link’.</source>
+        <target>There are ${count} options matching ‘Go to Copied Link’.</target>
         <note>Label showing how many widgets match ‘Go to Copied Link’. ${count} is a placeholder fo the number of widgets.</note>
       </trans-unit>
       <trans-unit id="fi3W24-eHmH1H" xml:space="preserve">
         <source>There are ${count} options matching ‘Clear Private Tabs’.</source>
+        <target>There are ${count} options matching ‘Clear Private Tabs’.</target>
         <note>Label showing how many widgets match ‘Clear Private Tabs’. ${count} is a placeholder fo the number of widgets.</note>
       </trans-unit>
       <trans-unit id="fi3W24-scEmjs" xml:space="preserve">
         <source>There are ${count} options matching ‘New Private Search’.</source>
+        <target>There are ${count} options matching ‘New Private Search’.</target>
         <note>Label showing how many widgets match ‘New Private Search’. ${count} is a placeholder fo the number of widgets.</note>
       </trans-unit>
       <trans-unit id="fi3W24-xRJbBP" xml:space="preserve">
         <source>There are ${count} options matching ‘New Search’.</source>
+        <target>There are ${count} options matching ‘New Search’.</target>
         <note>Label showing how many widgets match ‘New Search’. ${count} is a placeholder fo the number of widgets.</note>
       </trans-unit>
       <trans-unit id="scEmjs" xml:space="preserve">
         <source>New Private Search</source>
+        <target>New Private Search</target>
         <note>Quick Actions drop down menu item for new private search when widget enters edit mode and drop down menu expands</note>
       </trans-unit>
       <trans-unit id="w9jdPK" xml:space="preserve">
         <source>Quick Action</source>
+        <target>Quick Action</target>
         <note>Quick Actions left label text for dropdown menu when widget enters edit mode</note>
       </trans-unit>
       <trans-unit id="xRJbBP" xml:space="preserve">
         <source>New Search</source>
+        <target>New Search</target>
         <note>Quick Actions drop down menu item for new search when widget enters edit mode and drop down menu expands</note>
       </trans-unit>
     </body>

--- a/mr/firefox-ios.xliff
+++ b/mr/firefox-ios.xliff
@@ -1,5 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 http://docs.oasis-open.org/xliff/v1.2/os/xliff-core-1.2-strict.xsd">
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?><xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 http://docs.oasis-open.org/xliff/v1.2/os/xliff-core-1.2-strict.xsd">
   <file original="Client/en.lproj/InfoPlist.strings" source-language="en" target-language="mr" datatype="plaintext">
     <header>
       <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="13.4.1" build-num="13F100"/>
@@ -3436,7 +3435,7 @@
       </trans-unit>
     </body>
   </file>
-  <file original="Shared/en.lproj/Today.strings" source-language="en" target-language="mr" datatype="plaintext">
+  <file original="Shared/en.lproj/Today.strings" datatype="plaintext" source-language="en" target-language="mr">
     <header>
       <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="13.4.1" build-num="13F100"/>
     </header>
@@ -3527,7 +3526,7 @@ Private Tab</source>
       </trans-unit>
     </body>
   </file>
-  <file original="Shared/Supporting Files/en.lproj/BookmarkPanel.strings" datatype="plaintext" source-language="en" target-language="mr">
+  <file original="Shared/Supporting Files/en.lproj/BookmarkPanel.strings" source-language="en" target-language="mr" datatype="plaintext">
     <header>
       <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="13.4.1" build-num="13F100"/>
     </header>
@@ -3595,66 +3594,82 @@ Private Tab</source>
     <body>
       <trans-unit id="2GqvPe" xml:space="preserve">
         <source>Go to Copied Link</source>
+        <target>Go to Copied Link</target>
         <note>Quick Actions drop down menu item for Go to Copied Link when widget enters edit mode and drop down menu expands</note>
       </trans-unit>
       <trans-unit id="PzSrmZ-2GqvPe" xml:space="preserve">
         <source>Just to confirm, you wanted ‘Go to Copied Link’?</source>
+        <target>Just to confirm, you wanted ‘Go to Copied Link’?</target>
         <note>Accessibility label to confirm the go to copied link selection</note>
       </trans-unit>
       <trans-unit id="PzSrmZ-eHmH1H" xml:space="preserve">
         <source>Just to confirm, you wanted ‘Clear Private Tabs’?</source>
+        <target>Just to confirm, you wanted ‘Clear Private Tabs’?</target>
         <note>Accessibility label to confirm the Clear Private Tabs selection</note>
       </trans-unit>
       <trans-unit id="PzSrmZ-scEmjs" xml:space="preserve">
         <source>Just to confirm, you wanted ‘New Private Search’?</source>
+        <target>Just to confirm, you wanted ‘New Private Search’?</target>
         <note>Accessibility label to confirm the New Private Search selection</note>
       </trans-unit>
       <trans-unit id="PzSrmZ-xRJbBP" xml:space="preserve">
         <source>Just to confirm, you wanted ‘New Search’?</source>
+        <target>Just to confirm, you wanted ‘New Search’?</target>
         <note>Accessibility label to confirm the New Search selection</note>
       </trans-unit>
       <trans-unit id="ctDNmu" xml:space="preserve">
         <source>Quick access to various Firefox actions</source>
+        <target>Quick access to various Firefox actions</target>
         <note>Description of the collection of widgets</note>
       </trans-unit>
       <trans-unit id="eHmH1H" xml:space="preserve">
         <source>Clear Private Tabs</source>
+        <target>Clear Private Tabs</target>
         <note>Quick Actions drop down menu item for lear Private Tabs when widget enters edit mode and drop down menu expands</note>
       </trans-unit>
       <trans-unit id="eV8mOT" xml:space="preserve">
         <source>Quick Action Type</source>
+        <target>Quick Action Type</target>
         <note>The description of a customizable section of the widget</note>
       </trans-unit>
       <trans-unit id="eqyNJg" xml:space="preserve">
         <source>Quick Action</source>
+        <target>Quick Action</target>
         <note>Title of the quick actions widgets</note>
       </trans-unit>
       <trans-unit id="fi3W24-2GqvPe" xml:space="preserve">
         <source>There are ${count} options matching ‘Go to Copied Link’.</source>
+        <target>There are ${count} options matching ‘Go to Copied Link’.</target>
         <note>Label showing how many widgets match ‘Go to Copied Link’. ${count} is a placeholder fo the number of widgets.</note>
       </trans-unit>
       <trans-unit id="fi3W24-eHmH1H" xml:space="preserve">
         <source>There are ${count} options matching ‘Clear Private Tabs’.</source>
+        <target>There are ${count} options matching ‘Clear Private Tabs’.</target>
         <note>Label showing how many widgets match ‘Clear Private Tabs’. ${count} is a placeholder fo the number of widgets.</note>
       </trans-unit>
       <trans-unit id="fi3W24-scEmjs" xml:space="preserve">
         <source>There are ${count} options matching ‘New Private Search’.</source>
+        <target>There are ${count} options matching ‘New Private Search’.</target>
         <note>Label showing how many widgets match ‘New Private Search’. ${count} is a placeholder fo the number of widgets.</note>
       </trans-unit>
       <trans-unit id="fi3W24-xRJbBP" xml:space="preserve">
         <source>There are ${count} options matching ‘New Search’.</source>
+        <target>There are ${count} options matching ‘New Search’.</target>
         <note>Label showing how many widgets match ‘New Search’. ${count} is a placeholder fo the number of widgets.</note>
       </trans-unit>
       <trans-unit id="scEmjs" xml:space="preserve">
         <source>New Private Search</source>
+        <target>New Private Search</target>
         <note>Quick Actions drop down menu item for new private search when widget enters edit mode and drop down menu expands</note>
       </trans-unit>
       <trans-unit id="w9jdPK" xml:space="preserve">
         <source>Quick Action</source>
+        <target>Quick Action</target>
         <note>Quick Actions left label text for dropdown menu when widget enters edit mode</note>
       </trans-unit>
       <trans-unit id="xRJbBP" xml:space="preserve">
         <source>New Search</source>
+        <target>New Search</target>
         <note>Quick Actions drop down menu item for new search when widget enters edit mode and drop down menu expands</note>
       </trans-unit>
     </body>

--- a/ms/firefox-ios.xliff
+++ b/ms/firefox-ios.xliff
@@ -1,5 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 http://docs.oasis-open.org/xliff/v1.2/os/xliff-core-1.2-strict.xsd">
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?><xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 http://docs.oasis-open.org/xliff/v1.2/os/xliff-core-1.2-strict.xsd">
   <file original="Client/en.lproj/InfoPlist.strings" source-language="en" target-language="ms" datatype="plaintext">
     <header>
       <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="13.4.1" build-num="13F100"/>
@@ -189,7 +188,7 @@
       </trans-unit>
     </body>
   </file>
-  <file original="Shared/en.lproj/Default Browser.strings" source-language="en" target-language="ms" datatype="plaintext">
+  <file original="Shared/en.lproj/Default Browser.strings" datatype="plaintext" source-language="en" target-language="ms">
     <header>
       <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="13.4.1" build-num="13F100"/>
     </header>
@@ -3346,7 +3345,7 @@
       </trans-unit>
     </body>
   </file>
-  <file original="Shared/en.lproj/Today.strings" source-language="en" target-language="ms" datatype="plaintext">
+  <file original="Shared/en.lproj/Today.strings" datatype="plaintext" source-language="en" target-language="ms">
     <header>
       <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="13.4.1" build-num="13F100"/>
     </header>
@@ -3437,7 +3436,7 @@ Private Tab</source>
       </trans-unit>
     </body>
   </file>
-  <file original="Shared/Supporting Files/en.lproj/BookmarkPanel.strings" datatype="plaintext" source-language="en" target-language="ms">
+  <file original="Shared/Supporting Files/en.lproj/BookmarkPanel.strings" source-language="en" target-language="ms" datatype="plaintext">
     <header>
       <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="13.4.1" build-num="13F100"/>
     </header>
@@ -3505,66 +3504,82 @@ Private Tab</source>
     <body>
       <trans-unit id="2GqvPe" xml:space="preserve">
         <source>Go to Copied Link</source>
+        <target>Go to Copied Link</target>
         <note>Quick Actions drop down menu item for Go to Copied Link when widget enters edit mode and drop down menu expands</note>
       </trans-unit>
       <trans-unit id="PzSrmZ-2GqvPe" xml:space="preserve">
         <source>Just to confirm, you wanted ‘Go to Copied Link’?</source>
+        <target>Just to confirm, you wanted ‘Go to Copied Link’?</target>
         <note>Accessibility label to confirm the go to copied link selection</note>
       </trans-unit>
       <trans-unit id="PzSrmZ-eHmH1H" xml:space="preserve">
         <source>Just to confirm, you wanted ‘Clear Private Tabs’?</source>
+        <target>Just to confirm, you wanted ‘Clear Private Tabs’?</target>
         <note>Accessibility label to confirm the Clear Private Tabs selection</note>
       </trans-unit>
       <trans-unit id="PzSrmZ-scEmjs" xml:space="preserve">
         <source>Just to confirm, you wanted ‘New Private Search’?</source>
+        <target>Just to confirm, you wanted ‘New Private Search’?</target>
         <note>Accessibility label to confirm the New Private Search selection</note>
       </trans-unit>
       <trans-unit id="PzSrmZ-xRJbBP" xml:space="preserve">
         <source>Just to confirm, you wanted ‘New Search’?</source>
+        <target>Just to confirm, you wanted ‘New Search’?</target>
         <note>Accessibility label to confirm the New Search selection</note>
       </trans-unit>
       <trans-unit id="ctDNmu" xml:space="preserve">
         <source>Quick access to various Firefox actions</source>
+        <target>Quick access to various Firefox actions</target>
         <note>Description of the collection of widgets</note>
       </trans-unit>
       <trans-unit id="eHmH1H" xml:space="preserve">
         <source>Clear Private Tabs</source>
+        <target>Clear Private Tabs</target>
         <note>Quick Actions drop down menu item for lear Private Tabs when widget enters edit mode and drop down menu expands</note>
       </trans-unit>
       <trans-unit id="eV8mOT" xml:space="preserve">
         <source>Quick Action Type</source>
+        <target>Quick Action Type</target>
         <note>The description of a customizable section of the widget</note>
       </trans-unit>
       <trans-unit id="eqyNJg" xml:space="preserve">
         <source>Quick Action</source>
+        <target>Quick Action</target>
         <note>Title of the quick actions widgets</note>
       </trans-unit>
       <trans-unit id="fi3W24-2GqvPe" xml:space="preserve">
         <source>There are ${count} options matching ‘Go to Copied Link’.</source>
+        <target>There are ${count} options matching ‘Go to Copied Link’.</target>
         <note>Label showing how many widgets match ‘Go to Copied Link’. ${count} is a placeholder fo the number of widgets.</note>
       </trans-unit>
       <trans-unit id="fi3W24-eHmH1H" xml:space="preserve">
         <source>There are ${count} options matching ‘Clear Private Tabs’.</source>
+        <target>There are ${count} options matching ‘Clear Private Tabs’.</target>
         <note>Label showing how many widgets match ‘Clear Private Tabs’. ${count} is a placeholder fo the number of widgets.</note>
       </trans-unit>
       <trans-unit id="fi3W24-scEmjs" xml:space="preserve">
         <source>There are ${count} options matching ‘New Private Search’.</source>
+        <target>There are ${count} options matching ‘New Private Search’.</target>
         <note>Label showing how many widgets match ‘New Private Search’. ${count} is a placeholder fo the number of widgets.</note>
       </trans-unit>
       <trans-unit id="fi3W24-xRJbBP" xml:space="preserve">
         <source>There are ${count} options matching ‘New Search’.</source>
+        <target>There are ${count} options matching ‘New Search’.</target>
         <note>Label showing how many widgets match ‘New Search’. ${count} is a placeholder fo the number of widgets.</note>
       </trans-unit>
       <trans-unit id="scEmjs" xml:space="preserve">
         <source>New Private Search</source>
+        <target>New Private Search</target>
         <note>Quick Actions drop down menu item for new private search when widget enters edit mode and drop down menu expands</note>
       </trans-unit>
       <trans-unit id="w9jdPK" xml:space="preserve">
         <source>Quick Action</source>
+        <target>Quick Action</target>
         <note>Quick Actions left label text for dropdown menu when widget enters edit mode</note>
       </trans-unit>
       <trans-unit id="xRJbBP" xml:space="preserve">
         <source>New Search</source>
+        <target>New Search</target>
         <note>Quick Actions drop down menu item for new search when widget enters edit mode and drop down menu expands</note>
       </trans-unit>
     </body>

--- a/my/firefox-ios.xliff
+++ b/my/firefox-ios.xliff
@@ -1,5 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 http://docs.oasis-open.org/xliff/v1.2/os/xliff-core-1.2-strict.xsd">
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?><xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 http://docs.oasis-open.org/xliff/v1.2/os/xliff-core-1.2-strict.xsd">
   <file original="Client/en.lproj/InfoPlist.strings" source-language="en" target-language="my" datatype="plaintext">
     <header>
       <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="13.4.1" build-num="13F100"/>
@@ -3573,7 +3572,7 @@ Private Tab</source>
       </trans-unit>
     </body>
   </file>
-  <file original="Shared/Supporting Files/en.lproj/BookmarkPanel.strings" datatype="plaintext" source-language="en" target-language="my">
+  <file original="Shared/Supporting Files/en.lproj/BookmarkPanel.strings" source-language="en" target-language="my" datatype="plaintext">
     <header>
       <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="13.4.1" build-num="13F100"/>
     </header>
@@ -3641,66 +3640,82 @@ Private Tab</source>
     <body>
       <trans-unit id="2GqvPe" xml:space="preserve">
         <source>Go to Copied Link</source>
+        <target>Go to Copied Link</target>
         <note>Quick Actions drop down menu item for Go to Copied Link when widget enters edit mode and drop down menu expands</note>
       </trans-unit>
       <trans-unit id="PzSrmZ-2GqvPe" xml:space="preserve">
         <source>Just to confirm, you wanted ‘Go to Copied Link’?</source>
+        <target>Just to confirm, you wanted ‘Go to Copied Link’?</target>
         <note>Accessibility label to confirm the go to copied link selection</note>
       </trans-unit>
       <trans-unit id="PzSrmZ-eHmH1H" xml:space="preserve">
         <source>Just to confirm, you wanted ‘Clear Private Tabs’?</source>
+        <target>Just to confirm, you wanted ‘Clear Private Tabs’?</target>
         <note>Accessibility label to confirm the Clear Private Tabs selection</note>
       </trans-unit>
       <trans-unit id="PzSrmZ-scEmjs" xml:space="preserve">
         <source>Just to confirm, you wanted ‘New Private Search’?</source>
+        <target>Just to confirm, you wanted ‘New Private Search’?</target>
         <note>Accessibility label to confirm the New Private Search selection</note>
       </trans-unit>
       <trans-unit id="PzSrmZ-xRJbBP" xml:space="preserve">
         <source>Just to confirm, you wanted ‘New Search’?</source>
+        <target>Just to confirm, you wanted ‘New Search’?</target>
         <note>Accessibility label to confirm the New Search selection</note>
       </trans-unit>
       <trans-unit id="ctDNmu" xml:space="preserve">
         <source>Quick access to various Firefox actions</source>
+        <target>Quick access to various Firefox actions</target>
         <note>Description of the collection of widgets</note>
       </trans-unit>
       <trans-unit id="eHmH1H" xml:space="preserve">
         <source>Clear Private Tabs</source>
+        <target>Clear Private Tabs</target>
         <note>Quick Actions drop down menu item for lear Private Tabs when widget enters edit mode and drop down menu expands</note>
       </trans-unit>
       <trans-unit id="eV8mOT" xml:space="preserve">
         <source>Quick Action Type</source>
+        <target>Quick Action Type</target>
         <note>The description of a customizable section of the widget</note>
       </trans-unit>
       <trans-unit id="eqyNJg" xml:space="preserve">
         <source>Quick Action</source>
+        <target>Quick Action</target>
         <note>Title of the quick actions widgets</note>
       </trans-unit>
       <trans-unit id="fi3W24-2GqvPe" xml:space="preserve">
         <source>There are ${count} options matching ‘Go to Copied Link’.</source>
+        <target>There are ${count} options matching ‘Go to Copied Link’.</target>
         <note>Label showing how many widgets match ‘Go to Copied Link’. ${count} is a placeholder fo the number of widgets.</note>
       </trans-unit>
       <trans-unit id="fi3W24-eHmH1H" xml:space="preserve">
         <source>There are ${count} options matching ‘Clear Private Tabs’.</source>
+        <target>There are ${count} options matching ‘Clear Private Tabs’.</target>
         <note>Label showing how many widgets match ‘Clear Private Tabs’. ${count} is a placeholder fo the number of widgets.</note>
       </trans-unit>
       <trans-unit id="fi3W24-scEmjs" xml:space="preserve">
         <source>There are ${count} options matching ‘New Private Search’.</source>
+        <target>There are ${count} options matching ‘New Private Search’.</target>
         <note>Label showing how many widgets match ‘New Private Search’. ${count} is a placeholder fo the number of widgets.</note>
       </trans-unit>
       <trans-unit id="fi3W24-xRJbBP" xml:space="preserve">
         <source>There are ${count} options matching ‘New Search’.</source>
+        <target>There are ${count} options matching ‘New Search’.</target>
         <note>Label showing how many widgets match ‘New Search’. ${count} is a placeholder fo the number of widgets.</note>
       </trans-unit>
       <trans-unit id="scEmjs" xml:space="preserve">
         <source>New Private Search</source>
+        <target>New Private Search</target>
         <note>Quick Actions drop down menu item for new private search when widget enters edit mode and drop down menu expands</note>
       </trans-unit>
       <trans-unit id="w9jdPK" xml:space="preserve">
         <source>Quick Action</source>
+        <target>Quick Action</target>
         <note>Quick Actions left label text for dropdown menu when widget enters edit mode</note>
       </trans-unit>
       <trans-unit id="xRJbBP" xml:space="preserve">
         <source>New Search</source>
+        <target>New Search</target>
         <note>Quick Actions drop down menu item for new search when widget enters edit mode and drop down menu expands</note>
       </trans-unit>
     </body>

--- a/oc/firefox-ios.xliff
+++ b/oc/firefox-ios.xliff
@@ -1,5 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 http://docs.oasis-open.org/xliff/v1.2/os/xliff-core-1.2-strict.xsd">
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?><xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 http://docs.oasis-open.org/xliff/v1.2/os/xliff-core-1.2-strict.xsd">
   <file original="Client/en.lproj/InfoPlist.strings" source-language="en" target-language="oc" datatype="plaintext">
     <header>
       <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="13.4.1" build-num="13F100"/>
@@ -189,7 +188,7 @@
       </trans-unit>
     </body>
   </file>
-  <file original="Shared/en.lproj/Default Browser.strings" source-language="en" target-language="oc" datatype="plaintext">
+  <file original="Shared/en.lproj/Default Browser.strings" datatype="plaintext" source-language="en" target-language="oc">
     <header>
       <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="13.4.1" build-num="13F100"/>
     </header>
@@ -3355,7 +3354,7 @@
       </trans-unit>
     </body>
   </file>
-  <file original="Shared/en.lproj/Today.strings" source-language="en" target-language="oc" datatype="plaintext">
+  <file original="Shared/en.lproj/Today.strings" datatype="plaintext" source-language="en" target-language="oc">
     <header>
       <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="13.4.1" build-num="13F100"/>
     </header>
@@ -3446,7 +3445,7 @@ Private Tab</source>
       </trans-unit>
     </body>
   </file>
-  <file original="Shared/Supporting Files/en.lproj/BookmarkPanel.strings" datatype="plaintext" source-language="en" target-language="oc">
+  <file original="Shared/Supporting Files/en.lproj/BookmarkPanel.strings" source-language="en" target-language="oc" datatype="plaintext">
     <header>
       <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="13.4.1" build-num="13F100"/>
     </header>
@@ -3514,66 +3513,82 @@ Private Tab</source>
     <body>
       <trans-unit id="2GqvPe" xml:space="preserve">
         <source>Go to Copied Link</source>
+        <target>Go to Copied Link</target>
         <note>Quick Actions drop down menu item for Go to Copied Link when widget enters edit mode and drop down menu expands</note>
       </trans-unit>
       <trans-unit id="PzSrmZ-2GqvPe" xml:space="preserve">
         <source>Just to confirm, you wanted ‘Go to Copied Link’?</source>
+        <target>Just to confirm, you wanted ‘Go to Copied Link’?</target>
         <note>Accessibility label to confirm the go to copied link selection</note>
       </trans-unit>
       <trans-unit id="PzSrmZ-eHmH1H" xml:space="preserve">
         <source>Just to confirm, you wanted ‘Clear Private Tabs’?</source>
+        <target>Just to confirm, you wanted ‘Clear Private Tabs’?</target>
         <note>Accessibility label to confirm the Clear Private Tabs selection</note>
       </trans-unit>
       <trans-unit id="PzSrmZ-scEmjs" xml:space="preserve">
         <source>Just to confirm, you wanted ‘New Private Search’?</source>
+        <target>Just to confirm, you wanted ‘New Private Search’?</target>
         <note>Accessibility label to confirm the New Private Search selection</note>
       </trans-unit>
       <trans-unit id="PzSrmZ-xRJbBP" xml:space="preserve">
         <source>Just to confirm, you wanted ‘New Search’?</source>
+        <target>Just to confirm, you wanted ‘New Search’?</target>
         <note>Accessibility label to confirm the New Search selection</note>
       </trans-unit>
       <trans-unit id="ctDNmu" xml:space="preserve">
         <source>Quick access to various Firefox actions</source>
+        <target>Quick access to various Firefox actions</target>
         <note>Description of the collection of widgets</note>
       </trans-unit>
       <trans-unit id="eHmH1H" xml:space="preserve">
         <source>Clear Private Tabs</source>
+        <target>Clear Private Tabs</target>
         <note>Quick Actions drop down menu item for lear Private Tabs when widget enters edit mode and drop down menu expands</note>
       </trans-unit>
       <trans-unit id="eV8mOT" xml:space="preserve">
         <source>Quick Action Type</source>
+        <target>Quick Action Type</target>
         <note>The description of a customizable section of the widget</note>
       </trans-unit>
       <trans-unit id="eqyNJg" xml:space="preserve">
         <source>Quick Action</source>
+        <target>Quick Action</target>
         <note>Title of the quick actions widgets</note>
       </trans-unit>
       <trans-unit id="fi3W24-2GqvPe" xml:space="preserve">
         <source>There are ${count} options matching ‘Go to Copied Link’.</source>
+        <target>There are ${count} options matching ‘Go to Copied Link’.</target>
         <note>Label showing how many widgets match ‘Go to Copied Link’. ${count} is a placeholder fo the number of widgets.</note>
       </trans-unit>
       <trans-unit id="fi3W24-eHmH1H" xml:space="preserve">
         <source>There are ${count} options matching ‘Clear Private Tabs’.</source>
+        <target>There are ${count} options matching ‘Clear Private Tabs’.</target>
         <note>Label showing how many widgets match ‘Clear Private Tabs’. ${count} is a placeholder fo the number of widgets.</note>
       </trans-unit>
       <trans-unit id="fi3W24-scEmjs" xml:space="preserve">
         <source>There are ${count} options matching ‘New Private Search’.</source>
+        <target>There are ${count} options matching ‘New Private Search’.</target>
         <note>Label showing how many widgets match ‘New Private Search’. ${count} is a placeholder fo the number of widgets.</note>
       </trans-unit>
       <trans-unit id="fi3W24-xRJbBP" xml:space="preserve">
         <source>There are ${count} options matching ‘New Search’.</source>
+        <target>There are ${count} options matching ‘New Search’.</target>
         <note>Label showing how many widgets match ‘New Search’. ${count} is a placeholder fo the number of widgets.</note>
       </trans-unit>
       <trans-unit id="scEmjs" xml:space="preserve">
         <source>New Private Search</source>
+        <target>New Private Search</target>
         <note>Quick Actions drop down menu item for new private search when widget enters edit mode and drop down menu expands</note>
       </trans-unit>
       <trans-unit id="w9jdPK" xml:space="preserve">
         <source>Quick Action</source>
+        <target>Quick Action</target>
         <note>Quick Actions left label text for dropdown menu when widget enters edit mode</note>
       </trans-unit>
       <trans-unit id="xRJbBP" xml:space="preserve">
         <source>New Search</source>
+        <target>New Search</target>
         <note>Quick Actions drop down menu item for new search when widget enters edit mode and drop down menu expands</note>
       </trans-unit>
     </body>

--- a/or/firefox-ios.xliff
+++ b/or/firefox-ios.xliff
@@ -1,5 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 http://docs.oasis-open.org/xliff/v1.2/os/xliff-core-1.2-strict.xsd">
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?><xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 http://docs.oasis-open.org/xliff/v1.2/os/xliff-core-1.2-strict.xsd">
   <file original="Client/en.lproj/InfoPlist.strings" source-language="en" target-language="or" datatype="plaintext">
     <header>
       <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="13.4.1" build-num="13F100"/>
@@ -189,7 +188,7 @@
       </trans-unit>
     </body>
   </file>
-  <file original="Shared/en.lproj/Default Browser.strings" source-language="en" target-language="or" datatype="plaintext">
+  <file original="Shared/en.lproj/Default Browser.strings" datatype="plaintext" source-language="en" target-language="or">
     <header>
       <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="13.4.1" build-num="13F100"/>
     </header>
@@ -3045,7 +3044,7 @@
       </trans-unit>
     </body>
   </file>
-  <file original="Shared/en.lproj/Menu.strings" source-language="en" target-language="or" datatype="plaintext">
+  <file original="Shared/en.lproj/Menu.strings" datatype="plaintext" source-language="en" target-language="or">
     <header>
       <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="13.4.1" build-num="13F100"/>
     </header>
@@ -3128,7 +3127,7 @@
       </trans-unit>
     </body>
   </file>
-  <file original="Shared/en.lproj/PrivateBrowsing.strings" source-language="en" target-language="or" datatype="plaintext">
+  <file original="Shared/en.lproj/PrivateBrowsing.strings" datatype="plaintext" source-language="en" target-language="or">
     <header>
       <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="13.4.1" build-num="13F100"/>
     </header>
@@ -3175,7 +3174,7 @@
       </trans-unit>
     </body>
   </file>
-  <file original="Shared/en.lproj/Search.strings" source-language="en" target-language="or" datatype="plaintext">
+  <file original="Shared/en.lproj/Search.strings" datatype="plaintext" source-language="en" target-language="or">
     <header>
       <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="13.4.1" build-num="13F100"/>
     </header>
@@ -3190,7 +3189,7 @@
       </trans-unit>
     </body>
   </file>
-  <file original="Shared/en.lproj/Shared.strings" source-language="en" target-language="or" datatype="plaintext">
+  <file original="Shared/en.lproj/Shared.strings" datatype="plaintext" source-language="en" target-language="or">
     <header>
       <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="13.4.1" build-num="13F100"/>
     </header>
@@ -3201,7 +3200,7 @@
       </trans-unit>
     </body>
   </file>
-  <file original="Shared/en.lproj/Storage.strings" source-language="en" target-language="or" datatype="plaintext">
+  <file original="Shared/en.lproj/Storage.strings" datatype="plaintext" source-language="en" target-language="or">
     <header>
       <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="13.4.1" build-num="13F100"/>
     </header>
@@ -3224,7 +3223,7 @@
       </trans-unit>
     </body>
   </file>
-  <file original="Shared/en.lproj/Today.strings" source-language="en" target-language="or" datatype="plaintext">
+  <file original="Shared/en.lproj/Today.strings" datatype="plaintext" source-language="en" target-language="or">
     <header>
       <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="13.4.1" build-num="13F100"/>
     </header>
@@ -3315,7 +3314,7 @@ Private Tab</source>
       </trans-unit>
     </body>
   </file>
-  <file original="Shared/Supporting Files/en.lproj/BookmarkPanel.strings" datatype="plaintext" source-language="en" target-language="or">
+  <file original="Shared/Supporting Files/en.lproj/BookmarkPanel.strings" source-language="en" target-language="or" datatype="plaintext">
     <header>
       <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="13.4.1" build-num="13F100"/>
     </header>
@@ -3383,66 +3382,82 @@ Private Tab</source>
     <body>
       <trans-unit id="2GqvPe" xml:space="preserve">
         <source>Go to Copied Link</source>
+        <target>Go to Copied Link</target>
         <note>Quick Actions drop down menu item for Go to Copied Link when widget enters edit mode and drop down menu expands</note>
       </trans-unit>
       <trans-unit id="PzSrmZ-2GqvPe" xml:space="preserve">
         <source>Just to confirm, you wanted ‘Go to Copied Link’?</source>
+        <target>Just to confirm, you wanted ‘Go to Copied Link’?</target>
         <note>Accessibility label to confirm the go to copied link selection</note>
       </trans-unit>
       <trans-unit id="PzSrmZ-eHmH1H" xml:space="preserve">
         <source>Just to confirm, you wanted ‘Clear Private Tabs’?</source>
+        <target>Just to confirm, you wanted ‘Clear Private Tabs’?</target>
         <note>Accessibility label to confirm the Clear Private Tabs selection</note>
       </trans-unit>
       <trans-unit id="PzSrmZ-scEmjs" xml:space="preserve">
         <source>Just to confirm, you wanted ‘New Private Search’?</source>
+        <target>Just to confirm, you wanted ‘New Private Search’?</target>
         <note>Accessibility label to confirm the New Private Search selection</note>
       </trans-unit>
       <trans-unit id="PzSrmZ-xRJbBP" xml:space="preserve">
         <source>Just to confirm, you wanted ‘New Search’?</source>
+        <target>Just to confirm, you wanted ‘New Search’?</target>
         <note>Accessibility label to confirm the New Search selection</note>
       </trans-unit>
       <trans-unit id="ctDNmu" xml:space="preserve">
         <source>Quick access to various Firefox actions</source>
+        <target>Quick access to various Firefox actions</target>
         <note>Description of the collection of widgets</note>
       </trans-unit>
       <trans-unit id="eHmH1H" xml:space="preserve">
         <source>Clear Private Tabs</source>
+        <target>Clear Private Tabs</target>
         <note>Quick Actions drop down menu item for lear Private Tabs when widget enters edit mode and drop down menu expands</note>
       </trans-unit>
       <trans-unit id="eV8mOT" xml:space="preserve">
         <source>Quick Action Type</source>
+        <target>Quick Action Type</target>
         <note>The description of a customizable section of the widget</note>
       </trans-unit>
       <trans-unit id="eqyNJg" xml:space="preserve">
         <source>Quick Action</source>
+        <target>Quick Action</target>
         <note>Title of the quick actions widgets</note>
       </trans-unit>
       <trans-unit id="fi3W24-2GqvPe" xml:space="preserve">
         <source>There are ${count} options matching ‘Go to Copied Link’.</source>
+        <target>There are ${count} options matching ‘Go to Copied Link’.</target>
         <note>Label showing how many widgets match ‘Go to Copied Link’. ${count} is a placeholder fo the number of widgets.</note>
       </trans-unit>
       <trans-unit id="fi3W24-eHmH1H" xml:space="preserve">
         <source>There are ${count} options matching ‘Clear Private Tabs’.</source>
+        <target>There are ${count} options matching ‘Clear Private Tabs’.</target>
         <note>Label showing how many widgets match ‘Clear Private Tabs’. ${count} is a placeholder fo the number of widgets.</note>
       </trans-unit>
       <trans-unit id="fi3W24-scEmjs" xml:space="preserve">
         <source>There are ${count} options matching ‘New Private Search’.</source>
+        <target>There are ${count} options matching ‘New Private Search’.</target>
         <note>Label showing how many widgets match ‘New Private Search’. ${count} is a placeholder fo the number of widgets.</note>
       </trans-unit>
       <trans-unit id="fi3W24-xRJbBP" xml:space="preserve">
         <source>There are ${count} options matching ‘New Search’.</source>
+        <target>There are ${count} options matching ‘New Search’.</target>
         <note>Label showing how many widgets match ‘New Search’. ${count} is a placeholder fo the number of widgets.</note>
       </trans-unit>
       <trans-unit id="scEmjs" xml:space="preserve">
         <source>New Private Search</source>
+        <target>New Private Search</target>
         <note>Quick Actions drop down menu item for new private search when widget enters edit mode and drop down menu expands</note>
       </trans-unit>
       <trans-unit id="w9jdPK" xml:space="preserve">
         <source>Quick Action</source>
+        <target>Quick Action</target>
         <note>Quick Actions left label text for dropdown menu when widget enters edit mode</note>
       </trans-unit>
       <trans-unit id="xRJbBP" xml:space="preserve">
         <source>New Search</source>
+        <target>New Search</target>
         <note>Quick Actions drop down menu item for new search when widget enters edit mode and drop down menu expands</note>
       </trans-unit>
     </body>

--- a/ro/firefox-ios.xliff
+++ b/ro/firefox-ios.xliff
@@ -1,5 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 http://docs.oasis-open.org/xliff/v1.2/os/xliff-core-1.2-strict.xsd">
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?><xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 http://docs.oasis-open.org/xliff/v1.2/os/xliff-core-1.2-strict.xsd">
   <file original="Client/en.lproj/InfoPlist.strings" source-language="en" target-language="ro" datatype="plaintext">
     <header>
       <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="13.4.1" build-num="13F100"/>
@@ -3577,7 +3576,7 @@ Private Tab</source>
       </trans-unit>
     </body>
   </file>
-  <file original="Shared/Supporting Files/en.lproj/BookmarkPanel.strings" datatype="plaintext" source-language="en" target-language="ro">
+  <file original="Shared/Supporting Files/en.lproj/BookmarkPanel.strings" source-language="en" target-language="ro" datatype="plaintext">
     <header>
       <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="13.4.1" build-num="13F100"/>
     </header>
@@ -3645,66 +3644,82 @@ Private Tab</source>
     <body>
       <trans-unit id="2GqvPe" xml:space="preserve">
         <source>Go to Copied Link</source>
+        <target>Go to Copied Link</target>
         <note>Quick Actions drop down menu item for Go to Copied Link when widget enters edit mode and drop down menu expands</note>
       </trans-unit>
       <trans-unit id="PzSrmZ-2GqvPe" xml:space="preserve">
         <source>Just to confirm, you wanted ‘Go to Copied Link’?</source>
+        <target>Just to confirm, you wanted ‘Go to Copied Link’?</target>
         <note>Accessibility label to confirm the go to copied link selection</note>
       </trans-unit>
       <trans-unit id="PzSrmZ-eHmH1H" xml:space="preserve">
         <source>Just to confirm, you wanted ‘Clear Private Tabs’?</source>
+        <target>Just to confirm, you wanted ‘Clear Private Tabs’?</target>
         <note>Accessibility label to confirm the Clear Private Tabs selection</note>
       </trans-unit>
       <trans-unit id="PzSrmZ-scEmjs" xml:space="preserve">
         <source>Just to confirm, you wanted ‘New Private Search’?</source>
+        <target>Just to confirm, you wanted ‘New Private Search’?</target>
         <note>Accessibility label to confirm the New Private Search selection</note>
       </trans-unit>
       <trans-unit id="PzSrmZ-xRJbBP" xml:space="preserve">
         <source>Just to confirm, you wanted ‘New Search’?</source>
+        <target>Just to confirm, you wanted ‘New Search’?</target>
         <note>Accessibility label to confirm the New Search selection</note>
       </trans-unit>
       <trans-unit id="ctDNmu" xml:space="preserve">
         <source>Quick access to various Firefox actions</source>
+        <target>Quick access to various Firefox actions</target>
         <note>Description of the collection of widgets</note>
       </trans-unit>
       <trans-unit id="eHmH1H" xml:space="preserve">
         <source>Clear Private Tabs</source>
+        <target>Clear Private Tabs</target>
         <note>Quick Actions drop down menu item for lear Private Tabs when widget enters edit mode and drop down menu expands</note>
       </trans-unit>
       <trans-unit id="eV8mOT" xml:space="preserve">
         <source>Quick Action Type</source>
+        <target>Quick Action Type</target>
         <note>The description of a customizable section of the widget</note>
       </trans-unit>
       <trans-unit id="eqyNJg" xml:space="preserve">
         <source>Quick Action</source>
+        <target>Quick Action</target>
         <note>Title of the quick actions widgets</note>
       </trans-unit>
       <trans-unit id="fi3W24-2GqvPe" xml:space="preserve">
         <source>There are ${count} options matching ‘Go to Copied Link’.</source>
+        <target>There are ${count} options matching ‘Go to Copied Link’.</target>
         <note>Label showing how many widgets match ‘Go to Copied Link’. ${count} is a placeholder fo the number of widgets.</note>
       </trans-unit>
       <trans-unit id="fi3W24-eHmH1H" xml:space="preserve">
         <source>There are ${count} options matching ‘Clear Private Tabs’.</source>
+        <target>There are ${count} options matching ‘Clear Private Tabs’.</target>
         <note>Label showing how many widgets match ‘Clear Private Tabs’. ${count} is a placeholder fo the number of widgets.</note>
       </trans-unit>
       <trans-unit id="fi3W24-scEmjs" xml:space="preserve">
         <source>There are ${count} options matching ‘New Private Search’.</source>
+        <target>There are ${count} options matching ‘New Private Search’.</target>
         <note>Label showing how many widgets match ‘New Private Search’. ${count} is a placeholder fo the number of widgets.</note>
       </trans-unit>
       <trans-unit id="fi3W24-xRJbBP" xml:space="preserve">
         <source>There are ${count} options matching ‘New Search’.</source>
+        <target>There are ${count} options matching ‘New Search’.</target>
         <note>Label showing how many widgets match ‘New Search’. ${count} is a placeholder fo the number of widgets.</note>
       </trans-unit>
       <trans-unit id="scEmjs" xml:space="preserve">
         <source>New Private Search</source>
+        <target>New Private Search</target>
         <note>Quick Actions drop down menu item for new private search when widget enters edit mode and drop down menu expands</note>
       </trans-unit>
       <trans-unit id="w9jdPK" xml:space="preserve">
         <source>Quick Action</source>
+        <target>Quick Action</target>
         <note>Quick Actions left label text for dropdown menu when widget enters edit mode</note>
       </trans-unit>
       <trans-unit id="xRJbBP" xml:space="preserve">
         <source>New Search</source>
+        <target>New Search</target>
         <note>Quick Actions drop down menu item for new search when widget enters edit mode and drop down menu expands</note>
       </trans-unit>
     </body>

--- a/ses/firefox-ios.xliff
+++ b/ses/firefox-ios.xliff
@@ -1,5 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 http://docs.oasis-open.org/xliff/v1.2/os/xliff-core-1.2-strict.xsd">
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?><xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 http://docs.oasis-open.org/xliff/v1.2/os/xliff-core-1.2-strict.xsd">
   <file original="Client/en.lproj/InfoPlist.strings" source-language="en" target-language="ses" datatype="plaintext">
     <header>
       <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="13.4.1" build-num="13F100"/>
@@ -189,7 +188,7 @@
       </trans-unit>
     </body>
   </file>
-  <file original="Shared/en.lproj/Default Browser.strings" source-language="en" target-language="ses" datatype="plaintext">
+  <file original="Shared/en.lproj/Default Browser.strings" datatype="plaintext" source-language="en" target-language="ses">
     <header>
       <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="13.4.1" build-num="13F100"/>
     </header>
@@ -3346,7 +3345,7 @@
       </trans-unit>
     </body>
   </file>
-  <file original="Shared/en.lproj/Today.strings" source-language="en" target-language="ses" datatype="plaintext">
+  <file original="Shared/en.lproj/Today.strings" datatype="plaintext" source-language="en" target-language="ses">
     <header>
       <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="13.4.1" build-num="13F100"/>
     </header>
@@ -3437,7 +3436,7 @@ Private Tab</source>
       </trans-unit>
     </body>
   </file>
-  <file original="Shared/Supporting Files/en.lproj/BookmarkPanel.strings" datatype="plaintext" source-language="en" target-language="ses">
+  <file original="Shared/Supporting Files/en.lproj/BookmarkPanel.strings" source-language="en" target-language="ses" datatype="plaintext">
     <header>
       <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="13.4.1" build-num="13F100"/>
     </header>
@@ -3505,66 +3504,82 @@ Private Tab</source>
     <body>
       <trans-unit id="2GqvPe" xml:space="preserve">
         <source>Go to Copied Link</source>
+        <target>Go to Copied Link</target>
         <note>Quick Actions drop down menu item for Go to Copied Link when widget enters edit mode and drop down menu expands</note>
       </trans-unit>
       <trans-unit id="PzSrmZ-2GqvPe" xml:space="preserve">
         <source>Just to confirm, you wanted ‘Go to Copied Link’?</source>
+        <target>Just to confirm, you wanted ‘Go to Copied Link’?</target>
         <note>Accessibility label to confirm the go to copied link selection</note>
       </trans-unit>
       <trans-unit id="PzSrmZ-eHmH1H" xml:space="preserve">
         <source>Just to confirm, you wanted ‘Clear Private Tabs’?</source>
+        <target>Just to confirm, you wanted ‘Clear Private Tabs’?</target>
         <note>Accessibility label to confirm the Clear Private Tabs selection</note>
       </trans-unit>
       <trans-unit id="PzSrmZ-scEmjs" xml:space="preserve">
         <source>Just to confirm, you wanted ‘New Private Search’?</source>
+        <target>Just to confirm, you wanted ‘New Private Search’?</target>
         <note>Accessibility label to confirm the New Private Search selection</note>
       </trans-unit>
       <trans-unit id="PzSrmZ-xRJbBP" xml:space="preserve">
         <source>Just to confirm, you wanted ‘New Search’?</source>
+        <target>Just to confirm, you wanted ‘New Search’?</target>
         <note>Accessibility label to confirm the New Search selection</note>
       </trans-unit>
       <trans-unit id="ctDNmu" xml:space="preserve">
         <source>Quick access to various Firefox actions</source>
+        <target>Quick access to various Firefox actions</target>
         <note>Description of the collection of widgets</note>
       </trans-unit>
       <trans-unit id="eHmH1H" xml:space="preserve">
         <source>Clear Private Tabs</source>
+        <target>Clear Private Tabs</target>
         <note>Quick Actions drop down menu item for lear Private Tabs when widget enters edit mode and drop down menu expands</note>
       </trans-unit>
       <trans-unit id="eV8mOT" xml:space="preserve">
         <source>Quick Action Type</source>
+        <target>Quick Action Type</target>
         <note>The description of a customizable section of the widget</note>
       </trans-unit>
       <trans-unit id="eqyNJg" xml:space="preserve">
         <source>Quick Action</source>
+        <target>Quick Action</target>
         <note>Title of the quick actions widgets</note>
       </trans-unit>
       <trans-unit id="fi3W24-2GqvPe" xml:space="preserve">
         <source>There are ${count} options matching ‘Go to Copied Link’.</source>
+        <target>There are ${count} options matching ‘Go to Copied Link’.</target>
         <note>Label showing how many widgets match ‘Go to Copied Link’. ${count} is a placeholder fo the number of widgets.</note>
       </trans-unit>
       <trans-unit id="fi3W24-eHmH1H" xml:space="preserve">
         <source>There are ${count} options matching ‘Clear Private Tabs’.</source>
+        <target>There are ${count} options matching ‘Clear Private Tabs’.</target>
         <note>Label showing how many widgets match ‘Clear Private Tabs’. ${count} is a placeholder fo the number of widgets.</note>
       </trans-unit>
       <trans-unit id="fi3W24-scEmjs" xml:space="preserve">
         <source>There are ${count} options matching ‘New Private Search’.</source>
+        <target>There are ${count} options matching ‘New Private Search’.</target>
         <note>Label showing how many widgets match ‘New Private Search’. ${count} is a placeholder fo the number of widgets.</note>
       </trans-unit>
       <trans-unit id="fi3W24-xRJbBP" xml:space="preserve">
         <source>There are ${count} options matching ‘New Search’.</source>
+        <target>There are ${count} options matching ‘New Search’.</target>
         <note>Label showing how many widgets match ‘New Search’. ${count} is a placeholder fo the number of widgets.</note>
       </trans-unit>
       <trans-unit id="scEmjs" xml:space="preserve">
         <source>New Private Search</source>
+        <target>New Private Search</target>
         <note>Quick Actions drop down menu item for new private search when widget enters edit mode and drop down menu expands</note>
       </trans-unit>
       <trans-unit id="w9jdPK" xml:space="preserve">
         <source>Quick Action</source>
+        <target>Quick Action</target>
         <note>Quick Actions left label text for dropdown menu when widget enters edit mode</note>
       </trans-unit>
       <trans-unit id="xRJbBP" xml:space="preserve">
         <source>New Search</source>
+        <target>New Search</target>
         <note>Quick Actions drop down menu item for new search when widget enters edit mode and drop down menu expands</note>
       </trans-unit>
     </body>

--- a/ta/firefox-ios.xliff
+++ b/ta/firefox-ios.xliff
@@ -1,5 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 http://docs.oasis-open.org/xliff/v1.2/os/xliff-core-1.2-strict.xsd">
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?><xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 http://docs.oasis-open.org/xliff/v1.2/os/xliff-core-1.2-strict.xsd">
   <file original="Client/en.lproj/InfoPlist.strings" source-language="en" target-language="ta" datatype="plaintext">
     <header>
       <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="13.4.1" build-num="13F100"/>
@@ -189,7 +188,7 @@
       </trans-unit>
     </body>
   </file>
-  <file original="Shared/en.lproj/Default Browser.strings" source-language="en" target-language="ta" datatype="plaintext">
+  <file original="Shared/en.lproj/Default Browser.strings" datatype="plaintext" source-language="en" target-language="ta">
     <header>
       <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="13.4.1" build-num="13F100"/>
     </header>
@@ -3549,7 +3548,7 @@ Private Tab</source>
       </trans-unit>
     </body>
   </file>
-  <file original="Shared/Supporting Files/en.lproj/BookmarkPanel.strings" datatype="plaintext" source-language="en" target-language="ta">
+  <file original="Shared/Supporting Files/en.lproj/BookmarkPanel.strings" source-language="en" target-language="ta" datatype="plaintext">
     <header>
       <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="13.4.1" build-num="13F100"/>
     </header>
@@ -3617,66 +3616,82 @@ Private Tab</source>
     <body>
       <trans-unit id="2GqvPe" xml:space="preserve">
         <source>Go to Copied Link</source>
+        <target>Go to Copied Link</target>
         <note>Quick Actions drop down menu item for Go to Copied Link when widget enters edit mode and drop down menu expands</note>
       </trans-unit>
       <trans-unit id="PzSrmZ-2GqvPe" xml:space="preserve">
         <source>Just to confirm, you wanted ‘Go to Copied Link’?</source>
+        <target>Just to confirm, you wanted ‘Go to Copied Link’?</target>
         <note>Accessibility label to confirm the go to copied link selection</note>
       </trans-unit>
       <trans-unit id="PzSrmZ-eHmH1H" xml:space="preserve">
         <source>Just to confirm, you wanted ‘Clear Private Tabs’?</source>
+        <target>Just to confirm, you wanted ‘Clear Private Tabs’?</target>
         <note>Accessibility label to confirm the Clear Private Tabs selection</note>
       </trans-unit>
       <trans-unit id="PzSrmZ-scEmjs" xml:space="preserve">
         <source>Just to confirm, you wanted ‘New Private Search’?</source>
+        <target>Just to confirm, you wanted ‘New Private Search’?</target>
         <note>Accessibility label to confirm the New Private Search selection</note>
       </trans-unit>
       <trans-unit id="PzSrmZ-xRJbBP" xml:space="preserve">
         <source>Just to confirm, you wanted ‘New Search’?</source>
+        <target>Just to confirm, you wanted ‘New Search’?</target>
         <note>Accessibility label to confirm the New Search selection</note>
       </trans-unit>
       <trans-unit id="ctDNmu" xml:space="preserve">
         <source>Quick access to various Firefox actions</source>
+        <target>Quick access to various Firefox actions</target>
         <note>Description of the collection of widgets</note>
       </trans-unit>
       <trans-unit id="eHmH1H" xml:space="preserve">
         <source>Clear Private Tabs</source>
+        <target>Clear Private Tabs</target>
         <note>Quick Actions drop down menu item for lear Private Tabs when widget enters edit mode and drop down menu expands</note>
       </trans-unit>
       <trans-unit id="eV8mOT" xml:space="preserve">
         <source>Quick Action Type</source>
+        <target>Quick Action Type</target>
         <note>The description of a customizable section of the widget</note>
       </trans-unit>
       <trans-unit id="eqyNJg" xml:space="preserve">
         <source>Quick Action</source>
+        <target>Quick Action</target>
         <note>Title of the quick actions widgets</note>
       </trans-unit>
       <trans-unit id="fi3W24-2GqvPe" xml:space="preserve">
         <source>There are ${count} options matching ‘Go to Copied Link’.</source>
+        <target>There are ${count} options matching ‘Go to Copied Link’.</target>
         <note>Label showing how many widgets match ‘Go to Copied Link’. ${count} is a placeholder fo the number of widgets.</note>
       </trans-unit>
       <trans-unit id="fi3W24-eHmH1H" xml:space="preserve">
         <source>There are ${count} options matching ‘Clear Private Tabs’.</source>
+        <target>There are ${count} options matching ‘Clear Private Tabs’.</target>
         <note>Label showing how many widgets match ‘Clear Private Tabs’. ${count} is a placeholder fo the number of widgets.</note>
       </trans-unit>
       <trans-unit id="fi3W24-scEmjs" xml:space="preserve">
         <source>There are ${count} options matching ‘New Private Search’.</source>
+        <target>There are ${count} options matching ‘New Private Search’.</target>
         <note>Label showing how many widgets match ‘New Private Search’. ${count} is a placeholder fo the number of widgets.</note>
       </trans-unit>
       <trans-unit id="fi3W24-xRJbBP" xml:space="preserve">
         <source>There are ${count} options matching ‘New Search’.</source>
+        <target>There are ${count} options matching ‘New Search’.</target>
         <note>Label showing how many widgets match ‘New Search’. ${count} is a placeholder fo the number of widgets.</note>
       </trans-unit>
       <trans-unit id="scEmjs" xml:space="preserve">
         <source>New Private Search</source>
+        <target>New Private Search</target>
         <note>Quick Actions drop down menu item for new private search when widget enters edit mode and drop down menu expands</note>
       </trans-unit>
       <trans-unit id="w9jdPK" xml:space="preserve">
         <source>Quick Action</source>
+        <target>Quick Action</target>
         <note>Quick Actions left label text for dropdown menu when widget enters edit mode</note>
       </trans-unit>
       <trans-unit id="xRJbBP" xml:space="preserve">
         <source>New Search</source>
+        <target>New Search</target>
         <note>Quick Actions drop down menu item for new search when widget enters edit mode and drop down menu expands</note>
       </trans-unit>
     </body>

--- a/te/firefox-ios.xliff
+++ b/te/firefox-ios.xliff
@@ -1,5 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 http://docs.oasis-open.org/xliff/v1.2/os/xliff-core-1.2-strict.xsd">
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?><xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 http://docs.oasis-open.org/xliff/v1.2/os/xliff-core-1.2-strict.xsd">
   <file original="Client/en.lproj/InfoPlist.strings" source-language="en" target-language="te" datatype="plaintext">
     <header>
       <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="13.4.1" build-num="13F100"/>
@@ -3605,7 +3604,7 @@ Private Tab</source>
       </trans-unit>
     </body>
   </file>
-  <file original="Shared/Supporting Files/en.lproj/BookmarkPanel.strings" datatype="plaintext" source-language="en" target-language="te">
+  <file original="Shared/Supporting Files/en.lproj/BookmarkPanel.strings" source-language="en" target-language="te" datatype="plaintext">
     <header>
       <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="13.4.1" build-num="13F100"/>
     </header>
@@ -3617,7 +3616,7 @@ Private Tab</source>
       </trans-unit>
     </body>
   </file>
-  <file original="Shared/Supporting Files/en.lproj/BookmarkPanelDeleteConfirm.strings" datatype="plaintext" source-language="en" target-language="te">
+  <file original="Shared/Supporting Files/en.lproj/BookmarkPanelDeleteConfirm.strings" source-language="en" target-language="te" datatype="plaintext">
     <header>
       <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="13.4.1" build-num="13F100"/>
     </header>
@@ -3681,22 +3680,27 @@ Private Tab</source>
       </trans-unit>
       <trans-unit id="PzSrmZ-2GqvPe" xml:space="preserve">
         <source>Just to confirm, you wanted ‘Go to Copied Link’?</source>
+        <target>Just to confirm, you wanted ‘Go to Copied Link’?</target>
         <note>Accessibility label to confirm the go to copied link selection</note>
       </trans-unit>
       <trans-unit id="PzSrmZ-eHmH1H" xml:space="preserve">
         <source>Just to confirm, you wanted ‘Clear Private Tabs’?</source>
+        <target>Just to confirm, you wanted ‘Clear Private Tabs’?</target>
         <note>Accessibility label to confirm the Clear Private Tabs selection</note>
       </trans-unit>
       <trans-unit id="PzSrmZ-scEmjs" xml:space="preserve">
         <source>Just to confirm, you wanted ‘New Private Search’?</source>
+        <target>Just to confirm, you wanted ‘New Private Search’?</target>
         <note>Accessibility label to confirm the New Private Search selection</note>
       </trans-unit>
       <trans-unit id="PzSrmZ-xRJbBP" xml:space="preserve">
         <source>Just to confirm, you wanted ‘New Search’?</source>
+        <target>Just to confirm, you wanted ‘New Search’?</target>
         <note>Accessibility label to confirm the New Search selection</note>
       </trans-unit>
       <trans-unit id="ctDNmu" xml:space="preserve">
         <source>Quick access to various Firefox actions</source>
+        <target>Quick access to various Firefox actions</target>
         <note>Description of the collection of widgets</note>
       </trans-unit>
       <trans-unit id="eHmH1H" xml:space="preserve">
@@ -3706,38 +3710,47 @@ Private Tab</source>
       </trans-unit>
       <trans-unit id="eV8mOT" xml:space="preserve">
         <source>Quick Action Type</source>
+        <target>Quick Action Type</target>
         <note>The description of a customizable section of the widget</note>
       </trans-unit>
       <trans-unit id="eqyNJg" xml:space="preserve">
         <source>Quick Action</source>
+        <target>Quick Action</target>
         <note>Title of the quick actions widgets</note>
       </trans-unit>
       <trans-unit id="fi3W24-2GqvPe" xml:space="preserve">
         <source>There are ${count} options matching ‘Go to Copied Link’.</source>
+        <target>There are ${count} options matching ‘Go to Copied Link’.</target>
         <note>Label showing how many widgets match ‘Go to Copied Link’. ${count} is a placeholder fo the number of widgets.</note>
       </trans-unit>
       <trans-unit id="fi3W24-eHmH1H" xml:space="preserve">
         <source>There are ${count} options matching ‘Clear Private Tabs’.</source>
+        <target>There are ${count} options matching ‘Clear Private Tabs’.</target>
         <note>Label showing how many widgets match ‘Clear Private Tabs’. ${count} is a placeholder fo the number of widgets.</note>
       </trans-unit>
       <trans-unit id="fi3W24-scEmjs" xml:space="preserve">
         <source>There are ${count} options matching ‘New Private Search’.</source>
+        <target>There are ${count} options matching ‘New Private Search’.</target>
         <note>Label showing how many widgets match ‘New Private Search’. ${count} is a placeholder fo the number of widgets.</note>
       </trans-unit>
       <trans-unit id="fi3W24-xRJbBP" xml:space="preserve">
         <source>There are ${count} options matching ‘New Search’.</source>
+        <target>There are ${count} options matching ‘New Search’.</target>
         <note>Label showing how many widgets match ‘New Search’. ${count} is a placeholder fo the number of widgets.</note>
       </trans-unit>
       <trans-unit id="scEmjs" xml:space="preserve">
         <source>New Private Search</source>
+        <target>New Private Search</target>
         <note>Quick Actions drop down menu item for new private search when widget enters edit mode and drop down menu expands</note>
       </trans-unit>
       <trans-unit id="w9jdPK" xml:space="preserve">
         <source>Quick Action</source>
+        <target>Quick Action</target>
         <note>Quick Actions left label text for dropdown menu when widget enters edit mode</note>
       </trans-unit>
       <trans-unit id="xRJbBP" xml:space="preserve">
         <source>New Search</source>
+        <target>New Search</target>
         <note>Quick Actions drop down menu item for new search when widget enters edit mode and drop down menu expands</note>
       </trans-unit>
     </body>

--- a/uz/firefox-ios.xliff
+++ b/uz/firefox-ios.xliff
@@ -1,5 +1,4 @@
-<?xml version='1.0' encoding='UTF-8'?>
-<xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 http://docs.oasis-open.org/xliff/v1.2/os/xliff-core-1.2-strict.xsd">
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?><xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2" xsi:schemaLocation="urn:oasis:names:tc:xliff:document:1.2 http://docs.oasis-open.org/xliff/v1.2/os/xliff-core-1.2-strict.xsd">
   <file original="Client/en.lproj/InfoPlist.strings" source-language="en" target-language="uz" datatype="plaintext">
     <header>
       <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="13.4.1" build-num="13F100"/>
@@ -188,7 +187,7 @@
       </trans-unit>
     </body>
   </file>
-  <file original="Shared/en.lproj/Default Browser.strings" source-language="en" target-language="uz" datatype="plaintext">
+  <file original="Shared/en.lproj/Default Browser.strings" datatype="plaintext" source-language="en" target-language="uz">
     <header>
       <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="13.4.1" build-num="13F100"/>
     </header>
@@ -3240,7 +3239,7 @@
       </trans-unit>
     </body>
   </file>
-  <file original="Shared/en.lproj/Today.strings" source-language="en" target-language="uz" datatype="plaintext">
+  <file original="Shared/en.lproj/Today.strings" datatype="plaintext" source-language="en" target-language="uz">
     <header>
       <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="13.4.1" build-num="13F100"/>
     </header>
@@ -3331,7 +3330,7 @@ Private Tab</source>
       </trans-unit>
     </body>
   </file>
-  <file original="Shared/Supporting Files/en.lproj/BookmarkPanel.strings" datatype="plaintext" source-language="en" target-language="uz">
+  <file original="Shared/Supporting Files/en.lproj/BookmarkPanel.strings" source-language="en" target-language="uz" datatype="plaintext">
     <header>
       <tool tool-id="com.apple.dt.xcode" tool-name="Xcode" tool-version="13.4.1" build-num="13F100"/>
     </header>
@@ -3399,66 +3398,82 @@ Private Tab</source>
     <body>
       <trans-unit id="2GqvPe" xml:space="preserve">
         <source>Go to Copied Link</source>
+        <target>Go to Copied Link</target>
         <note>Quick Actions drop down menu item for Go to Copied Link when widget enters edit mode and drop down menu expands</note>
       </trans-unit>
       <trans-unit id="PzSrmZ-2GqvPe" xml:space="preserve">
         <source>Just to confirm, you wanted ‘Go to Copied Link’?</source>
+        <target>Just to confirm, you wanted ‘Go to Copied Link’?</target>
         <note>Accessibility label to confirm the go to copied link selection</note>
       </trans-unit>
       <trans-unit id="PzSrmZ-eHmH1H" xml:space="preserve">
         <source>Just to confirm, you wanted ‘Clear Private Tabs’?</source>
+        <target>Just to confirm, you wanted ‘Clear Private Tabs’?</target>
         <note>Accessibility label to confirm the Clear Private Tabs selection</note>
       </trans-unit>
       <trans-unit id="PzSrmZ-scEmjs" xml:space="preserve">
         <source>Just to confirm, you wanted ‘New Private Search’?</source>
+        <target>Just to confirm, you wanted ‘New Private Search’?</target>
         <note>Accessibility label to confirm the New Private Search selection</note>
       </trans-unit>
       <trans-unit id="PzSrmZ-xRJbBP" xml:space="preserve">
         <source>Just to confirm, you wanted ‘New Search’?</source>
+        <target>Just to confirm, you wanted ‘New Search’?</target>
         <note>Accessibility label to confirm the New Search selection</note>
       </trans-unit>
       <trans-unit id="ctDNmu" xml:space="preserve">
         <source>Quick access to various Firefox actions</source>
+        <target>Quick access to various Firefox actions</target>
         <note>Description of the collection of widgets</note>
       </trans-unit>
       <trans-unit id="eHmH1H" xml:space="preserve">
         <source>Clear Private Tabs</source>
+        <target>Clear Private Tabs</target>
         <note>Quick Actions drop down menu item for lear Private Tabs when widget enters edit mode and drop down menu expands</note>
       </trans-unit>
       <trans-unit id="eV8mOT" xml:space="preserve">
         <source>Quick Action Type</source>
+        <target>Quick Action Type</target>
         <note>The description of a customizable section of the widget</note>
       </trans-unit>
       <trans-unit id="eqyNJg" xml:space="preserve">
         <source>Quick Action</source>
+        <target>Quick Action</target>
         <note>Title of the quick actions widgets</note>
       </trans-unit>
       <trans-unit id="fi3W24-2GqvPe" xml:space="preserve">
         <source>There are ${count} options matching ‘Go to Copied Link’.</source>
+        <target>There are ${count} options matching ‘Go to Copied Link’.</target>
         <note>Label showing how many widgets match ‘Go to Copied Link’. ${count} is a placeholder fo the number of widgets.</note>
       </trans-unit>
       <trans-unit id="fi3W24-eHmH1H" xml:space="preserve">
         <source>There are ${count} options matching ‘Clear Private Tabs’.</source>
+        <target>There are ${count} options matching ‘Clear Private Tabs’.</target>
         <note>Label showing how many widgets match ‘Clear Private Tabs’. ${count} is a placeholder fo the number of widgets.</note>
       </trans-unit>
       <trans-unit id="fi3W24-scEmjs" xml:space="preserve">
         <source>There are ${count} options matching ‘New Private Search’.</source>
+        <target>There are ${count} options matching ‘New Private Search’.</target>
         <note>Label showing how many widgets match ‘New Private Search’. ${count} is a placeholder fo the number of widgets.</note>
       </trans-unit>
       <trans-unit id="fi3W24-xRJbBP" xml:space="preserve">
         <source>There are ${count} options matching ‘New Search’.</source>
+        <target>There are ${count} options matching ‘New Search’.</target>
         <note>Label showing how many widgets match ‘New Search’. ${count} is a placeholder fo the number of widgets.</note>
       </trans-unit>
       <trans-unit id="scEmjs" xml:space="preserve">
         <source>New Private Search</source>
+        <target>New Private Search</target>
         <note>Quick Actions drop down menu item for new private search when widget enters edit mode and drop down menu expands</note>
       </trans-unit>
       <trans-unit id="w9jdPK" xml:space="preserve">
         <source>Quick Action</source>
+        <target>Quick Action</target>
         <note>Quick Actions left label text for dropdown menu when widget enters edit mode</note>
       </trans-unit>
       <trans-unit id="xRJbBP" xml:space="preserve">
         <source>New Search</source>
+        <target>New Search</target>
         <note>Quick Actions drop down menu item for new search when widget enters edit mode and drop down menu expands</note>
       </trans-unit>
     </body>


### PR DESCRIPTION
@flodolo I realized that if we don't export the changes I made in https://github.com/mozilla-mobile/firefox-ios/pull/11691 then it gets overridden by the string import. I made sure there's only the widget intent that is in this PR. The one strange thing I noticed is that the following files didn't receive any changes related to the widget kit:
- ga: Irish (ga-IE)
- fil: Filipino (tl)

In other words, those two files don't have the <target> defined for the strings from widget kit file `2GqvPe`, `eHmH1H`, `eV8mOT`, etc. which I find a bit odd as all others are fine.