### PR TITLE
Simplify string import scripts and workflows

### DIFF
--- a/.github/scripts/check_product_locales.py
+++ b/.github/scripts/check_product_locales.py
@@ -11,6 +11,7 @@ Check if Pontoon locales are missing in the repository for iOS projects.
 import argparse
 import requests
 import sys
+from locale_config import IOS_TO_PONTOON
 from urllib.parse import quote as urlquote
 
 
@@ -47,16 +48,6 @@ def getGithubLocales(repo, path):
     url = f"https://api.github.com{query}"
 
     ignored_locales = ["Base", "en", "en-US"]
-    locale_mapping = {
-        # iOS locale: Pontoon locale
-        "fil": "tl",
-        "ga": "ga-IE",
-        "nb": "nb-NO",
-        "nn": "nn-NO",
-        "sat-Olck": "sat",
-        "sv": "sv-SE",
-        "tzm": "zgh",
-    }
 
     try:
         response = requests.get(url)
@@ -71,7 +62,7 @@ def getGithubLocales(repo, path):
 
         # Remap locales and exclude en/en-US
         locale_list = [
-            locale_mapping.get(loc, loc)
+            IOS_TO_PONTOON.get(loc, loc)
             for loc in locale_list
             if loc not in ignored_locales
         ]

--- a/.github/scripts/check_target_language.py
+++ b/.github/scripts/check_target_language.py
@@ -1,0 +1,90 @@
+#! /usr/bin/env python3
+
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+"""
+check_target_language.py --path <base_l10n_folder>
+
+ Verify that every localized XLIFF file declares the expected
+ 'target-language' on each <file> node. Pontoon owns this attribute, so this
+ is a safety net that fails when a sync leaves a locale with the wrong (or
+ missing) language code.
+
+ The expected code matches the folder name, except for a few locales whose
+ language code differs from their Pontoon folder (see PONTOON_TO_IOS in
+ locale_config.py). The reference locale and the source-only 'templates' folder
+ are skipped.
+"""
+
+from glob import glob
+from locale_config import PONTOON_TO_IOS
+from lxml import etree
+import argparse
+import os
+import sys
+
+
+NS = {"x": "urn:oasis:names:tc:xliff:document:1.2"}
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--path",
+        required=True,
+        dest="base_folder",
+        help="Path to folder including subfolders for all locales",
+    )
+    parser.add_argument(
+        "--reference",
+        required=False,
+        default="en-US",
+        dest="reference_locale",
+        help="Reference locale code to skip (default: en-US)",
+    )
+    args = parser.parse_args()
+
+    base_folder = os.path.realpath(args.base_folder)
+    skip = {args.reference_locale, "templates"}
+
+    locales = sorted(
+        d
+        for d in os.listdir(base_folder)
+        if os.path.isdir(os.path.join(base_folder, d))
+        and not d.startswith(".")
+        and d not in skip
+    )
+
+    errors = []
+    for locale in locales:
+        expected = PONTOON_TO_IOS.get(locale, locale).replace("_", "-")
+        locale_path = os.path.join(base_folder, locale)
+        for xliff_path in glob(locale_path + "/**/*.xliff", recursive=True):
+            try:
+                root = etree.parse(xliff_path).getroot()
+            except Exception as e:
+                errors.append(f"{xliff_path}: can't parse ({e})")
+                continue
+
+            for file_node in root.xpath("//x:file", namespaces=NS):
+                actual = file_node.get("target-language")
+                if actual != expected:
+                    original = file_node.get("original")
+                    errors.append(
+                        f"{os.path.relpath(xliff_path, base_folder)} ({original}): "
+                        f"target-language is '{actual}', expected '{expected}'"
+                    )
+
+    if errors:
+        print("Incorrect target-language found:")
+        for error in errors:
+            print(f"  {error}")
+        sys.exit(1)
+
+    print(f"target-language is correct in {len(locales)} locales.")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/create_template.py
+++ b/.github/scripts/create_template.py
@@ -1,0 +1,75 @@
+#! /usr/bin/env python3
+
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+"""
+create_template.py --reference <ref_folder> --output <template_folder>
+
+ Generate the source-only template used by Pontoon from the reference locale.
+ For each reference XLIFF file, the tree is copied, all <target> elements are
+ removed, and the 'target-language' attribute is dropped from every <file>
+ node.
+"""
+
+from functions import write_xliff
+from glob import glob
+from lxml import etree
+import argparse
+import os
+import sys
+
+
+NS = {"x": "urn:oasis:names:tc:xliff:document:1.2"}
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--reference",
+        required=True,
+        dest="reference_path",
+        help="Path to folder with the reference XLIFF files",
+    )
+    parser.add_argument(
+        "--output",
+        required=True,
+        dest="output_path",
+        help="Path to the template folder",
+    )
+    args = parser.parse_args()
+
+    reference_path = os.path.realpath(args.reference_path)
+    output_path = os.path.realpath(args.output_path)
+
+    reference_files = glob(reference_path + "/**/*.xliff", recursive=True)
+    if not reference_files:
+        sys.exit(f"No reference file found in {reference_path}")
+    reference_files.sort()
+
+    for file_path in reference_files:
+        try:
+            tree = etree.parse(file_path)
+            root = tree.getroot()
+        except Exception as e:
+            sys.exit(f"ERROR: Can't parse reference file {file_path}\n{e}")
+
+        # Drop the target-language attribute from each <file> node.
+        for file_node in root.xpath("//x:file", namespaces=NS):
+            file_node.attrib.pop("target-language", None)
+
+        # Remove all translations.
+        for target in root.xpath("//x:target", namespaces=NS):
+            target.getparent().remove(target)
+
+        # Write the template mirroring the reference file paths.
+        relative_path = os.path.relpath(file_path, reference_path)
+        template_file = os.path.join(output_path, relative_path)
+        os.makedirs(os.path.dirname(template_file), exist_ok=True)
+        write_xliff(tree, template_file)
+        print(f"Created template {template_file}")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/create_templates.py
+++ b/.github/scripts/create_templates.py
@@ -5,7 +5,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 """
-create_template.py --reference <ref_folder> --output <template_folder>
+create_templates.py --reference <ref_folder> --output <template_folder>
 
  Generate the source-only template used by Pontoon from the reference locale.
  For each reference XLIFF file, the tree is copied, all <target> elements are

--- a/.github/scripts/locale_config.py
+++ b/.github/scripts/locale_config.py
@@ -1,0 +1,25 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+"""
+Shared locale configuration.
+
+A handful of locales use a different language code in the product (iOS) than
+the folder/Pontoon code used in this repository. This is the single source of
+truth for that mapping; consumers import the direction they need.
+"""
+
+# Canonical direction: Pontoon/folder code -> iOS target-language code.
+PONTOON_TO_IOS = {
+    "ga-IE": "ga",
+    "nb-NO": "nb",
+    "nn-NO": "nn",
+    "sat": "sat-Olck",
+    "sv-SE": "sv",
+    "tl": "fil",
+    "zgh": "tzm",
+}
+
+# Inverse: iOS product code -> Pontoon/folder code.
+IOS_TO_PONTOON = {ios: pontoon for pontoon, ios in PONTOON_TO_IOS.items()}

--- a/.github/scripts/requirements.txt
+++ b/.github/scripts/requirements.txt
@@ -1,3 +1,3 @@
-lxml~=6.1.0
+lxml~=6.1.1
 moz-xliff-linter~=0.1.1
-requests~=2.33.1
+requests~=2.34.2

--- a/.github/scripts/update_other_locales.py
+++ b/.github/scripts/update_other_locales.py
@@ -132,7 +132,7 @@ def main():
             if not os.path.isfile(l10n_file):
                 continue
 
-            print(f"Updating {l10n_file}")
+            print(f"Processing {l10n_file}")
 
             # Read localized XML file
             try:
@@ -197,7 +197,7 @@ def main():
     if updated_files == 0:
         sys.exit("No files updated.")
     else:
-        print(f"{updated_files} updated files.")
+        print(f"{updated_files} files processed.")
 
 
 if __name__ == "__main__":

--- a/.github/scripts/update_other_locales.py
+++ b/.github/scripts/update_other_locales.py
@@ -7,26 +7,31 @@
 """
 update_other_locales.py --reference <locale> --path <base_l10n_folder> [optional list of locales]
 
- First, get a list of all XLIFF files in the reference locale. Then, for
- each folder (locale) available in base_l10n_folder:
+ Every locale file is already kept structurally in sync with the reference by
+ Pontoon (same <file> and <trans-unit> elements). This script only edits
+ translations in place: for each existing <target>, it decides whether the
+ translation is still valid given the current reference, and removes it
+ otherwise. It never adds, removes, or reorders <trans-unit> elements.
 
- 1. Read existing translations, store them in an array: IDs use the structure
-    file_name:string_id:source_hash. Using the hash of the source string
-    prevents from keeping an existing translation if the ID doesn't change
-    but the source string does.
+ For each reference file, an index of the reference is built, keyed by
+ trans-unit ID and storing the list of (file, source) pairs where that ID
+ appears. Then, for each localized <trans-unit> that has a <target>:
 
-    If the '--nofile' argument is passed, the 'file_name' won't be used when
-    storing translations. This allows to retain translations when a string
-    moves as-is from one file to another.
-
- 2. Inject available translations in the reference XLIFF file, updating
-    the target-language where available on file elements.
-
- 3. Store the updated content in existing locale files, without backup.
+ - If the ID isn't in the reference, the trans-unit is left untouched (the
+   string is obsolete and will be removed by Pontoon).
+ - If the ID is in the reference, the '--type' argument decides:
+   - 'standard': keep the translation only if a reference entry matches both
+     file and source. Removes it if the source changed or the string moved to
+     a different file.
+   - 'nofile': keep the translation if a reference entry matches the source,
+     ignoring the file. This retains translations when a string moves as-is
+     from one file to another.
+   - 'matchid': always keep the translation, and update <source> to the
+     reference text if it changed. This retains translations for trivial
+     source changes.
 """
 
 from argparse import RawTextHelpFormatter
-from copy import deepcopy
 from functions import write_xliff
 from glob import glob
 from lxml import etree
@@ -67,6 +72,7 @@ def main():
     args = parser.parse_args()
 
     reference_locale = args.reference_locale
+    update_type = args.update_type
 
     # Get a list of files to update (absolute paths)
     base_folder = os.path.realpath(args.base_folder)
@@ -81,7 +87,8 @@ def main():
             f"No reference file found in {os.path.join(base_folder, reference_locale)}"
         )
 
-    # Get the list of locales
+    # Get the list of locales. 'templates' is generated separately, so it's
+    # excluded together with the reference locale.
     if args.locales:
         locales = args.locales
     else:
@@ -90,7 +97,9 @@ def main():
             for d in os.listdir(base_folder)
             if os.path.isdir(os.path.join(base_folder, d)) and not d.startswith(".")
         ]
-        locales.remove(reference_locale)
+        for excluded in (reference_locale, "templates"):
+            if excluded in locales:
+                locales.remove(excluded)
         locales.sort()
 
     updated_files = 0
@@ -99,17 +108,29 @@ def main():
         try:
             reference_file_path = os.path.join(base_folder, reference_locale, filename)
             reference_tree = etree.parse(reference_file_path)
+            reference_root = reference_tree.getroot()
         except Exception as e:
             sys.exit(f"ERROR: Can't parse reference file {filename}\n{e}")
+
+        """
+        Build an index of the reference content, keyed by trans-unit ID.
+        Each ID maps to the list of (file, source) pairs where it appears:
+        the same ID can be reused in different files (e.g. common keys like "
+        OK" or "Cancel"), so it isn't unique on its own.
+        """
+        reference_index = {}
+        for trans_node in reference_root.xpath("//x:trans-unit", namespaces=NS):
+            original_id = trans_node.get("id")
+            file_name = trans_node.getparent().getparent().get("original")
+            source_string = trans_node.xpath("./x:source", namespaces=NS)[0].text
+            reference_index.setdefault(original_id, []).append(
+                (file_name, source_string)
+            )
 
         for locale in locales:
             l10n_file = os.path.join(base_folder, locale, filename)
             if not os.path.isfile(l10n_file):
                 continue
-
-            # Make a copy of the reference tree and root
-            reference_tree_copy = deepcopy(reference_tree)
-            reference_root_copy = reference_tree_copy.getroot()
 
             print(f"Updating {l10n_file}")
 
@@ -122,98 +143,55 @@ def main():
                 print(e)
                 continue
 
-            """
-            Using locale folder as locale code for the target-language attribute.
-            This can be use to map a locale code to a different one.
-            Structure: "locale folder" -> "locale code"
-            """
-            locale_mapping = {
-                "ga-IE": "ga",
-                "nb-NO": "nb",
-                "nn-NO": "nn",
-                "sat": "sat-Olck",
-                "sv-SE": "sv",
-                "templates": "en",
-                "tl": "fil",
-                "zgh": "tzm",
-            }
-            # Normaliza the locale code, using dashes instead of underscores
-            locale_code = locale_mapping.get(locale, locale).replace("_", "-")
-
-            """
-            Store existing localizations in a dictionary.
-            The key for each translation is a combination of the <file> "original"
-            attribute, the <trans-unit> "id", and the <source> text.
-            This allows to invalidate a translation if the source string
-            changed without using a new ID (can be bypassed with --onlyid).
-            """
-            translations = {}
             for trans_node in locale_root.xpath("//x:trans-unit", namespaces=NS):
-                for child in trans_node.xpath("./x:target", namespaces=NS):
-                    file_name = trans_node.getparent().getparent().get("original")
-                    source_string = trans_node.xpath("./x:source", namespaces=NS)[
-                        0
-                    ].text
-                    original_id = trans_node.get("id")
-                    if args.update_type == "matchid":
-                        # Ignore source text and file attribute
-                        string_id = original_id
-                    else:
-                        if args.update_type == "nofile":
-                            string_id = f"{original_id}:{hash(source_string)}"
-                        else:
-                            string_id = (
-                                f"{file_name}:{original_id}:{hash(source_string)}"
-                            )
-                    translations[string_id] = child.text
+                targets = trans_node.xpath("./x:target", namespaces=NS)
+                if not targets:
+                    # Untranslated string, nothing to do.
+                    continue
+                target = targets[0]
 
-            # Inject available translations in the reference XML
-            for trans_node in reference_root_copy.xpath(
-                "//x:trans-unit", namespaces=NS
-            ):
-                # Add xml:space="preserve" to all trans-units, to avoid conflict
-                # with Pontoon
-                attrib_name = "{http://www.w3.org/XML/1998/namespace}space"
-                xml_space = trans_node.get(attrib_name)
-                if xml_space is None:
-                    trans_node.set(attrib_name, "preserve")
+                original_id = trans_node.get("id")
+                reference_entries = reference_index.get(original_id)
+                if reference_entries is None:
+                    # Obsolete string, not available in reference content.
+                    # Leave its removal to Pontoon.
+                    continue
 
                 file_name = trans_node.getparent().getparent().get("original")
-                source_string = trans_node.xpath("./x:source", namespaces=NS)[0].text
-                original_id = trans_node.get("id")
+                source_node = trans_node.xpath("./x:source", namespaces=NS)[0]
+                source_string = source_node.text
 
-                if args.update_type == "matchid":
-                    # Ignore source text and file attribute
-                    string_id = original_id
+                if update_type == "matchid":
+                    # Keep the translation and align the source to the reference.
+                    # Prefer the entry from the same file, since an ID can appear
+                    # in more than one file; otherwise fall back to the first.
+                    reference_source = reference_entries[0][1]
+                    for ref_file, ref_source in reference_entries:
+                        if ref_file == file_name:
+                            reference_source = ref_source
+                            break
+                    if source_string != reference_source:
+                        source_node.text = reference_source
+                    continue
+
+                if update_type == "nofile":
+                    # Keep if any reference entry has the same source.
+                    keep = any(
+                        source_string == ref_source
+                        for _, ref_source in reference_entries
+                    )
                 else:
-                    if args.update_type == "nofile":
-                        string_id = f"{original_id}:{hash(source_string)}"
-                    else:
-                        string_id = f"{file_name}:{original_id}:{hash(source_string)}"
-                updated = False
-                translated = string_id in translations
-                for child in trans_node.xpath("./x:target", namespaces=NS):
-                    if translated:
-                        child.text = translations[string_id]
-                    else:
-                        # No translation available, remove the target
-                        child.getparent().remove(child)
-                    updated = True
+                    # 'standard': keep if a reference entry matches file and source.
+                    keep = any(
+                        file_name == ref_file and source_string == ref_source
+                        for ref_file, ref_source in reference_entries
+                    )
 
-                if translated and not updated:
-                    # Translation is available, but the refence XLIFF has no target.
-                    # Create a target node and insert it after source.
-                    child = etree.Element("target")
-                    child.text = translations[string_id]
-                    trans_node.insert(1, child)
+                if not keep:
+                    target.getparent().remove(target)
 
-            # Update target-language where defined, replace underscores with
-            # hyphens if necessary (e.g. en_GB => en-GB).
-            for file_node in reference_root_copy.xpath("//x:file", namespaces=NS):
-                file_node.set("target-language", locale_code)
-
-            # Replace the existing locale file with the new XML content
-            write_xliff(reference_tree_copy, l10n_file)
+            # Replace the existing locale file with the updated XML content
+            write_xliff(locale_tree, l10n_file)
             updated_files += 1
 
     if updated_files == 0:

--- a/.github/scripts/update_other_locales.py
+++ b/.github/scripts/update_other_locales.py
@@ -120,11 +120,18 @@ def main():
         """
         reference_index = {}
         for trans_node in reference_root.xpath("//x:trans-unit", namespaces=NS):
+            source = trans_node.find("x:source", namespaces=NS)
+            if source is None:
+                # A reference unit without a source means a broken extraction.
+                # Exit with an error.
+                sys.exit(
+                    f"ERROR: Reference trans-unit '{trans_node.get('id')}' "
+                    f"has no source in {filename}"
+                )
             original_id = trans_node.get("id")
             file_name = trans_node.getparent().getparent().get("original")
-            source_string = trans_node.xpath("./x:source", namespaces=NS)[0].text
             reference_index.setdefault(original_id, []).append(
-                (file_name, source_string)
+                (file_name, source.text)
             )
 
         for locale in locales:
@@ -157,8 +164,15 @@ def main():
                     # Leave its removal to Pontoon.
                     continue
 
+                source_node = trans_node.find("x:source", namespaces=NS)
+                if source_node is None:
+                    # Malformed locale unit; log and skip.
+                    print(
+                        f"WARNING: Skipping trans-unit '{trans_node.get('id')}' "
+                        f"without source in {l10n_file}"
+                    )
+                    continue
                 file_name = trans_node.getparent().getparent().get("original")
-                source_node = trans_node.xpath("./x:source", namespaces=NS)[0]
                 source_string = source_node.text
 
                 if update_type == "matchid":

--- a/.github/workflows/check_product_locales.yml
+++ b/.github/workflows/check_product_locales.yml
@@ -9,11 +9,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Clone repository
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
       - name: Set up Python 3
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: "3.12"
       - name: Install Python dependencies

--- a/.github/workflows/check_reference_strings.yml
+++ b/.github/workflows/check_reference_strings.yml
@@ -20,11 +20,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Clone repository
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
       - name: Set up Python 3
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: "3.12"
       - name: Install Python dependencies

--- a/.github/workflows/check_target_language.yml
+++ b/.github/workflows/check_target_language.yml
@@ -13,11 +13,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Clone repository
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
       - name: Set up Python 3
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: "3.12"
       - name: Install Python dependencies

--- a/.github/workflows/check_target_language.yml
+++ b/.github/workflows/check_target_language.yml
@@ -1,0 +1,28 @@
+name: Check target-language
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - ".github/workflows/check_target_language.yml"
+      - ".github/scripts/check_target_language.py"
+      - "**/firefox-ios.xliff"
+  workflow_dispatch:
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+      - name: Set up Python 3
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3.12"
+      - name: Install Python dependencies
+        run: |
+          pip install -r .github/scripts/requirements.txt
+      - name: Check target-language
+        run: |
+          python .github/scripts/check_target_language.py --path .

--- a/.github/workflows/import_strings.yml
+++ b/.github/workflows/import_strings.yml
@@ -72,7 +72,7 @@ jobs:
           python .github/scripts/translate_reference.py --path ./en-US
 
           # Generate the source-only template used by Pontoon
-          python .github/scripts/create_template.py --reference ./en-US --output ./templates
+          python .github/scripts/create_templates.py --reference ./en-US --output ./templates
 
           # Copy strings over from es-ES to es, fixing the target-language.
           cp ./es-ES/*.xliff ./es/

--- a/.github/workflows/import_strings.yml
+++ b/.github/workflows/import_strings.yml
@@ -71,10 +71,14 @@ jobs:
           # use en.lproj instead of en-US.lproj.
           python .github/scripts/translate_reference.py --path ./en-US
 
-          # Copy strings over from es-ES to es
-          cp ./es-ES/*.xliff ./es/
+          # Generate the source-only template used by Pontoon
+          python .github/scripts/create_template.py --reference ./en-US --output ./templates
 
-          # Copy strings to other locales
+          # Copy strings over from es-ES to es, fixing the target-language.
+          cp ./es-ES/*.xliff ./es/
+          sed -i.bak 's/ target-language="es-ES"/ target-language="es"/' ./es/firefox-ios.xliff && rm -f ./es/firefox-ios.xliff.bak
+
+          # Update translations in localized files where necessary
           python .github/scripts/update_other_locales.py --reference en-US --path . --type "$TYPE"
         working-directory: l10n_repo
       - name: Import linter config

--- a/.github/workflows/import_strings.yml
+++ b/.github/workflows/import_strings.yml
@@ -19,12 +19,12 @@ jobs:
           - "26.5"
     steps:
       - name: Clone l10n repository
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
           path: "l10n_repo"
       - name: Clone main code repository
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
           repository: "mozilla-mobile/firefox-ios"
@@ -33,7 +33,7 @@ jobs:
         run: |
           sudo xcode-select -s /Applications/Xcode_${{ matrix.xcode }}.app
       - name: Set up Python 3
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: "3.12"
       - name: Install Python dependencies

--- a/README.md
+++ b/README.md
@@ -11,25 +11,32 @@ Matrix channel: [#fx-ios](https://chat.mozilla.org/#/room/%23fx-ios:mozilla.org)
 
 Automation is used to extract strings from the code repository, and expose them to all other locales.
 
-1. Strings are extracted and saved in the `en-US` XLIFF file.
-2. The updated `en-US` XLIFF is used as a template. Existing translations are copied over if all these elements match:
-    * `id` attribute of `trans-unit`.
-    * `original` attribute of `file`.
-    * `source` text.
+1. Strings are extracted and saved in the `en-US` XLIFF file (the reference).
+2. A source-only version (no translations) is written to `templates`, which is what Pontoon reads to keep every locale in sync.
+3. Existing translations are then updated in place: a translation is removed when its source string no longer matches the reference. This step only invalidates stale translations; adding and removing strings is left to Pontoon.
 
-As a consequence, the default update removes translations if:
+By default, a translation is kept only if all of these match against the reference:
+* `id` attribute of `trans-unit`.
+* `original` attribute of `file`.
+* `source` text.
+
+As a consequence, the default update removes a translation if:
 * The source text was changed.
 * The string was moved from one file to another.
 
 This is not ideal when the change in the source text is trivial, or the string move is caused by code refactoring.
 
 It’s possible to invoke [automation manually](https://github.com/mozilla-l10n/firefoxios-l10n/actions/workflows/import_strings.yml), and use a different matching criterion:
-* `nofile` will copy translations if the ID and source text match, ignoring the file. This is useful to minimize the impact of code refactoring.
-* `matchid` will ignore both file and source text, copying translations if the ID matches. This is useful for source changes that don’t require invalidating existing translations.
+* `nofile` keeps translations if the ID and source text match, ignoring the file. This is useful to minimize the impact of code refactoring.
+* `matchid` keeps translations if the ID matches, ignoring the file and source text. This is useful for source changes that don’t require invalidating existing translations.
 
 ## Linter for reference strings
 
 When opening a pull request that touches the `en-US` folder, a GitHub workflow is used to check for common issues in the reference strings (misused quotes or ellipsis, hard-coded brand names). It's possible to add exceptions in this [JSON file](.github/scripts/linter_config.json).
+
+## Target language check
+
+When opening a pull request that touches localized files, a GitHub workflow checks that each locale declares the expected `target-language`. This is a safety net for syncs that leave a locale with the wrong or missing language code. A few locales use a language code that differs from their folder name; the mapping lives in [`locale_config.py`](.github/scripts/locale_config.py).
 
 ## Locales in build
 


### PR DESCRIPTION
* Add separate scripts to generate `templates`  from `en-US`, and check the `target-language` attributes in PRs, instead of rewriting them all the time.
* Don't touch localized files unless `matchid` or `nofile` are specified, let Pontoon update these files on sync and create leaner PRs to review.
* Update action versions and requirements.