### PR TITLE
Use a separate workflow to generate es from es-ES

### DIFF
--- a/.github/scripts/update_other_locales.py
+++ b/.github/scripts/update_other_locales.py
@@ -87,8 +87,9 @@ def main():
             f"No reference file found in {os.path.join(base_folder, reference_locale)}"
         )
 
-    # Get the list of locales. 'templates' is generated separately, so it's
-    # excluded together with the reference locale.
+    # Get the list of locales. 'templates' is generated separately, and 'es' is
+    # a copy of es-ES maintained via workflow, so both are excluded together
+    # with the reference locale.
     if args.locales:
         locales = args.locales
     else:
@@ -97,7 +98,7 @@ def main():
             for d in os.listdir(base_folder)
             if os.path.isdir(os.path.join(base_folder, d)) and not d.startswith(".")
         ]
-        for excluded in (reference_locale, "templates"):
+        for excluded in (reference_locale, "templates", "es"):
             if excluded in locales:
                 locales.remove(excluded)
         locales.sort()

--- a/.github/workflows/import_strings.yml
+++ b/.github/workflows/import_strings.yml
@@ -74,10 +74,6 @@ jobs:
           # Generate the source-only template used by Pontoon
           python .github/scripts/create_templates.py --reference ./en-US --output ./templates
 
-          # Copy strings over from es-ES to es, fixing the target-language.
-          cp ./es-ES/*.xliff ./es/
-          sed -i.bak 's/ target-language="es-ES"/ target-language="es"/' ./es/firefox-ios.xliff && rm -f ./es/firefox-ios.xliff.bak
-
           # Update translations in localized files where necessary
           python .github/scripts/update_other_locales.py --reference en-US --path . --type "$TYPE"
         working-directory: l10n_repo

--- a/.github/workflows/update_es.yml
+++ b/.github/workflows/update_es.yml
@@ -1,0 +1,37 @@
+name: Update Spanish (es)
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "es-ES/firefox-ios.xliff"
+  schedule:
+    - cron: "0 5 * * *"
+  workflow_dispatch:
+concurrency:
+  group: update-es
+  cancel-in-progress: true
+jobs:
+  copy:
+    name: Copy translations
+    runs-on: ubuntu-latest
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          token: ${{ secrets.IOS_L10N_TOKEN }}
+      - name: Update es from es-ES and push
+        run: |
+          git config user.name "l10n-bot"
+          git config user.email "mozilla-pontoon@users.noreply.github.com"
+          # Copy translations from es-ES to es, fixing the target-language.
+          cp ./es-ES/*.xliff ./es/
+          sed -i.bak 's/ target-language="es-ES"/ target-language="es"/' ./es/firefox-ios.xliff && rm -f ./es/firefox-ios.xliff.bak
+          git add es/
+          if git diff-index --quiet HEAD; then
+            echo "es already up to date"
+            exit 0
+          fi
+          git commit -m "Update Spanish (es) localizations"
+          # If main was changed by Pontoon, it won't touch es/, so just rebase and try again.
+          git push || { git pull --rebase origin main && git push; }


### PR DESCRIPTION
The original automation was adding new strings to `es-ES`, then copying the file over as `es` and update the `target-language`.

The new automation only extracts new strings for `en-US` and `templates`, relying on Pontoon to update localized files. Since `es` is not enabled in Pontoon, it won't include the latest strings until the next extraction.

As a workaround, don't generate `es` during extraction and use a dedicated workflow:
- Update `es` as soon as `es-ES` is updated.
- Keep a daily schedule as fallback.