### PR TITLE
Fix automation for nofile/matchid

### DIFF
--- a/.github/scripts/check_target_language.py
+++ b/.github/scripts/check_target_language.py
@@ -5,7 +5,12 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 """
-check_target_language.py --path <base_l10n_folder>
+check_target_language.py --path <folder>
+     [--reference <locale>] [--project <name>]
+
+ --project selects the locale mapping and excluded folders from
+ locale_config.py. When no project name is provided, empty defaults are used
+ (no remapping, no excluded folders).
 
  Verify that every localized XLIFF file declares the expected
  'target-language' on each <file> node. Pontoon owns this attribute, so this

--- a/.github/scripts/check_target_language.py
+++ b/.github/scripts/check_target_language.py
@@ -13,20 +13,63 @@ check_target_language.py --path <base_l10n_folder>
  missing) language code.
 
  The expected code matches the folder name, except for a few locales whose
- language code differs from their Pontoon folder (see PONTOON_TO_IOS in
- locale_config.py). The reference locale and the source-only 'templates' folder
- are skipped.
+ language code differs from their Pontoon folder (see the project 'mapping' in
+ locale_config.py, selected with --project). The reference locale is skipped.
 """
 
-from glob import glob
-from locale_config import PONTOON_TO_IOS
-from lxml import etree
 import argparse
 import os
 import sys
+from glob import glob
 
+from functions import list_locales
+from locale_config import PROJECTS, get_locale_code, get_project_config
+from lxml import etree
 
 NS = {"x": "urn:oasis:names:tc:xliff:document:1.2"}
+
+
+def check_target_languages(
+    base_folder, reference_locale="en", mapping={}, excluded_folders=()
+):
+    """
+    Check every localized XLIFF file and return
+    (locales, parse_errors, target_errors):
+    - 'parse_errors': files that couldn't be parsed.
+    - 'target_errors': <file> nodes that don't declare the expected
+      target-language.
+    Both lists empty means everything is correct.
+
+    'mapping' is a Pontoon-folder -> XLIFF-code dict; 'excluded_folders' lists
+    non-locale folders to skip (see locale_config.get_project_config).
+    """
+    base_folder = os.path.realpath(base_folder)
+    locales = list_locales(
+        base_folder, excluded=excluded_folders, skip={reference_locale}
+    )
+
+    parse_errors = []
+    target_errors = []
+    for locale in locales:
+        expected = get_locale_code(mapping, locale)
+        locale_path = os.path.join(base_folder, locale)
+        for xliff_path in glob(locale_path + "/**/*.xliff", recursive=True):
+            try:
+                root = etree.parse(xliff_path).getroot()
+            except Exception as e:
+                parse_errors.append(f"{xliff_path}: can't parse ({e})")
+                continue
+
+            for file_node in root.xpath("//x:file", namespaces=NS):
+                actual = file_node.get("target-language")
+                if actual != expected:
+                    original = file_node.get("original")
+                    target_errors.append(
+                        f"{os.path.relpath(xliff_path, base_folder)} ({original}): "
+                        f"target-language is '{actual}', expected '{expected}'"
+                    )
+
+    return locales, parse_errors, target_errors
 
 
 def main():
@@ -40,47 +83,39 @@ def main():
     parser.add_argument(
         "--reference",
         required=False,
-        default="en-US",
+        default="en",
         dest="reference_locale",
-        help="Reference locale code to skip (default: en-US)",
+        help="Reference locale code to skip (default: en)",
+    )
+    parser.add_argument(
+        "--project",
+        required=False,
+        default=None,
+        choices=sorted(PROJECTS),
+        help="Project config to use (locale mapping + excluded folders). "
+        "Defaults to no mapping and no excluded folders.",
     )
     args = parser.parse_args()
 
-    base_folder = os.path.realpath(args.base_folder)
-    skip = {args.reference_locale, "templates"}
-
-    locales = sorted(
-        d
-        for d in os.listdir(base_folder)
-        if os.path.isdir(os.path.join(base_folder, d))
-        and not d.startswith(".")
-        and d not in skip
+    config = get_project_config(args.project)
+    locales, parse_errors, target_errors = check_target_languages(
+        args.base_folder,
+        args.reference_locale,
+        mapping=config["mapping"],
+        excluded_folders=config["excluded_folders"],
     )
 
-    errors = []
-    for locale in locales:
-        expected = PONTOON_TO_IOS.get(locale, locale).replace("_", "-")
-        locale_path = os.path.join(base_folder, locale)
-        for xliff_path in glob(locale_path + "/**/*.xliff", recursive=True):
-            try:
-                root = etree.parse(xliff_path).getroot()
-            except Exception as e:
-                errors.append(f"{xliff_path}: can't parse ({e})")
-                continue
-
-            for file_node in root.xpath("//x:file", namespaces=NS):
-                actual = file_node.get("target-language")
-                if actual != expected:
-                    original = file_node.get("original")
-                    errors.append(
-                        f"{os.path.relpath(xliff_path, base_folder)} ({original}): "
-                        f"target-language is '{actual}', expected '{expected}'"
-                    )
-
-    if errors:
-        print("Incorrect target-language found:")
-        for error in errors:
+    if parse_errors:
+        print("Files that could not be parsed:")
+        for error in parse_errors:
             print(f"  {error}")
+
+    if target_errors:
+        print("Incorrect target-language found:")
+        for error in target_errors:
+            print(f"  {error}")
+
+    if parse_errors or target_errors:
         sys.exit(1)
 
     print(f"target-language is correct in {len(locales)} locales.")

--- a/.github/scripts/functions.py
+++ b/.github/scripts/functions.py
@@ -1,9 +1,16 @@
+#! /usr/bin/env python3
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+import os
+
 from lxml import etree
 
 
 def write_xliff(root, filename):
     with open(filename, "w+") as fp:
-        # Fix identation of XML file
+        # Fix indentation of XML file
         etree.indent(root)
         """
         Hack to avoid conflicts with Pontoon, which uses single quotes
@@ -21,3 +28,21 @@ def write_xliff(root, filename):
             '<?xml version="1.0" encoding="utf-8"?>\n' + xliff_content.decode("utf-8")
         )
         fp.write(xliff_content)
+
+
+def list_locales(base_folder, excluded=(), skip=()):
+    """
+    Return a sorted list of locale folder names in base_folder, skipping
+    hidden folders, any name in `excluded` (project-specific non-locale folders),
+    and any name in `skip` (e.g. the reference locale).
+    """
+    excluded = set(excluded)
+    skip = set(skip)
+    return sorted(
+        d
+        for d in os.listdir(base_folder)
+        if os.path.isdir(os.path.join(base_folder, d))
+        and not d.startswith(".")
+        and d not in excluded
+        and d not in skip
+    )

--- a/.github/scripts/locale_config.py
+++ b/.github/scripts/locale_config.py
@@ -1,25 +1,76 @@
+#! /usr/bin/env python3
 # This Source Code Form is subject to the terms of the Mozilla Public
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 """
-Shared locale configuration.
+Per-project configuration for the XLIFF localization scripts.
 
-A handful of locales use a different language code in the product (iOS) than
-the folder/Pontoon code used in this repository. This is the single source of
-truth for that mapping; consumers import the direction they need.
+Each project defines:
+- 'mapping': Pontoon folder name -> XLIFF target-language code, for locales
+  whose folder name differs from the language code that should be used in the
+  XLIFF. The keys must match the actual folder names as they appear in the
+  project (the scripts normalize underscores to hyphens *after* this lookup,
+  so a folder named 'nb_NO' is keyed as 'nb_NO', a folder 'nb-NO' as 'nb-NO').
+- 'excluded_folders': top-level folders that sit next to the locale folders
+  but are not locales, or locales managed by automation (e.g. `es`), and
+  should be skipped when listing locales.
+
+Select a project on the command line with '--project <name>'. When no project
+is passed the scripts fall back to an empty config (no remapping, no excluded
+folders).
 """
 
-# Canonical direction: Pontoon/folder code -> iOS target-language code.
-PONTOON_TO_IOS = {
-    "ga-IE": "ga",
-    "nb-NO": "nb",
-    "nn-NO": "nn",
-    "sat": "sat-Olck",
-    "sv-SE": "sv",
-    "tl": "fil",
-    "zgh": "tzm",
+PROJECTS = {
+    "vpn": {
+        "mapping": {},
+        "excluded_folders": [],
+    },
+    "ios": {
+        "mapping": {
+            "ga-IE": "ga",
+            "nb-NO": "nb",
+            "nn-NO": "nn",
+            "sat": "sat-Olck",
+            "sv-SE": "sv",
+            "tl": "fil",
+            "zgh": "tzm",
+        },
+        "excluded_folders": [
+            "es",
+            "templates",
+        ],
+    },
 }
 
-# Inverse: iOS product code -> Pontoon/folder code.
-IOS_TO_PONTOON = {ios: pontoon for pontoon, ios in PONTOON_TO_IOS.items()}
+
+def get_project_config(project=None):
+    """
+    Return a project's config as {"mapping": {...}, "excluded_folders": [...]}.
+
+    With no project selected (None), return empty defaults so the scripts run
+    with no remapping and no excluded folders. An unknown project name raises
+    ValueError.
+    """
+    if project is None:
+        return {"mapping": {}, "excluded_folders": []}
+
+    try:
+        config = PROJECTS[project]
+    except KeyError:
+        available = ", ".join(sorted(PROJECTS))
+        raise ValueError(f"Unknown project '{project}'. Available: {available}")
+
+    return {
+        "mapping": dict(config.get("mapping", {})),
+        "excluded_folders": list(config.get("excluded_folders", [])),
+    }
+
+
+def get_locale_code(mapping, folder):
+    """
+    Resolve a Pontoon folder name to its XLIFF target-language code: apply the
+    project 'mapping' (if the folder has an entry), then normalize underscores
+    to hyphens (e.g. 'en_GB' -> 'en-GB').
+    """
+    return mapping.get(folder, folder).replace("_", "-")

--- a/.github/scripts/update_other_locales.py
+++ b/.github/scripts/update_other_locales.py
@@ -5,42 +5,301 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 """
-update_other_locales.py --reference <locale> --path <base_l10n_folder> [optional list of locales]
+update_other_locales.py --reference <locale> --path <folder> [locales...]
 
- Every locale file is already kept structurally in sync with the reference by
- Pontoon (same <file> and <trans-unit> elements). This script only edits
- translations in place: for each existing <target>, it decides whether the
- translation is still valid given the current reference, and removes it
- otherwise. It never adds, removes, or reorders <trans-unit> elements.
+ How each localized file is updated depends on the '--type' argument. The two
+ behaviors exist because they serve different goals.
 
- For each reference file, an index of the reference is built, keyed by
- trans-unit ID and storing the list of (file, source) pairs where that ID
- appears. Then, for each localized <trans-unit> that has a <target>:
+ 'standard' (in-place, updates owned by Pontoon)
+ -----------------------------------------------
+ Every locale file is already kept structurally in sync with the reference
+ by Pontoon (same <file> and <trans-unit> elements), so this mode only edits
+ translations in place and never adds, removes, or reorders <trans-unit> elements.
 
- - If the ID isn't in the reference, the trans-unit is left untouched (the
-   string is obsolete and will be removed by Pontoon).
- - If the ID is in the reference, the '--type' argument decides:
-   - 'standard': keep the translation only if a reference entry matches both
-     file and source. Removes it if the source changed or the string moved to
-     a different file.
-   - 'nofile': keep the translation if a reference entry matches the source,
-     ignoring the file. This retains translations when a string moves as-is
-     from one file to another.
-   - 'matchid': always keep the translation, and update <source> to the
-     reference text if it changed. This retains translations for trivial
-     source changes.
+ A localized <target> is removed *only* when the source text of that string
+ changed in the reference, without using a new ID. In every other case the
+ localized file is left untouched:
+ - String removed from the reference are left in place (Pontoon will remove them).
+ - String moved to a different file are left in place. 'nofile'/'matchid'
+   should be used to actually move the translation).
+
+ 'nofile' / 'matchid' (rebuild from reference, move existing translations)
+ -------------------------------------------------------------------------
+ Used for manual runs, typically after a refactor that moves strings between
+ files. These modes rebuild each localized file from the reference structure,
+ injecting the existing translations. Because the translations are injected onto
+ the reference structure, a string that moved to a different <file> block is
+ recreated (with its translation) under its new location, so the translation
+ isn't lost when Pontoon later syncs the structure.
+
+ Existing translations are matched by:
+ - 'nofile': trans-unit ID and source text, ignoring the file. Retains
+   translations when a string moves as-is from one file to another.
+ - 'matchid': trans-unit ID only. Retains translations for trivial source
+   changes, updating the source to match the reference.
+
+ Strings that are no longer in the reference (removed upstream) are *not*
+ dropped from localized files: their removal is left to Pontoon, matching the
+ 'standard' behavior. This ensures that PRs have the minimal diff possible,
+ making it easier to review and reducing merge conflicts.
 """
 
-from argparse import RawTextHelpFormatter
-from functions import write_xliff
-from glob import glob
-from lxml import etree
 import argparse
 import os
 import sys
+from argparse import RawTextHelpFormatter
+from copy import deepcopy
+from glob import glob
 
+from functions import list_locales, write_xliff
+from locale_config import PROJECTS, get_locale_code, get_project_config
+from lxml import etree
 
 NS = {"x": "urn:oasis:names:tc:xliff:document:1.2"}
+
+
+def translation_key(update_type, original_id, source_string):
+    """
+    Build the key used to match an existing translation against the reference
+    for the 'nofile'/'matchid' rebuild modes. Both ignore the file, so a moved
+    string is matched wherever it lives now.
+    """
+    if update_type == "matchid":
+        # Ignore source text: retain the translation even if the source changed.
+        return original_id
+    # 'nofile': invalidate on source change.
+    return f"{original_id}:{hash(source_string)}"
+
+
+def file_original(trans_node):
+    """Return the 'original' attribute of the <file> a trans-unit belongs to."""
+    return trans_node.xpath("ancestor::x:file", namespaces=NS)[0].get("original")
+
+
+def reorder_attributes(node, preferred_order):
+    """
+    Rewrite `node`'s attributes to follow `preferred_order` (a list of attribute
+    names); any attribute not listed keeps its relative order at the end. Used to
+    keep a rebuilt <file>'s attribute order identical to the localized file's, so
+    the reference declaring them in a different order doesn't create noise diffs.
+    """
+    current = dict(node.attrib)
+    ordered = [key for key in preferred_order if key in current]
+    ordered += [key for key in current if key not in ordered]
+    for key in list(node.attrib):
+        del node.attrib[key]
+    for key in ordered:
+        node.set(key, current[key])
+
+
+def build_reference_index(reference_root, filename):
+    """
+    Index the reference content as {id: {original_file: set(sources)}}.
+    """
+    reference_index = {}
+    for trans_node in reference_root.xpath("//x:trans-unit", namespaces=NS):
+        source = trans_node.find("x:source", namespaces=NS)
+        if source is None:
+            # A reference unit without a source means a broken extraction.
+            sys.exit(
+                f"ERROR: Reference trans-unit '{trans_node.get('id')}' "
+                f"has no source in {filename}"
+            )
+        per_file = reference_index.setdefault(trans_node.get("id"), {})
+        per_file.setdefault(file_original(trans_node), set()).add(source.text)
+    return reference_index
+
+
+def update_in_place(reference_index, locale_root):
+    """
+    'standard' mode: remove a localized <target> only when the source text
+    changed in the reference for the same XLIFF file. Strings removed upstream
+    or moved to a different file are left untouched.
+    """
+    for trans_node in locale_root.xpath("//x:trans-unit", namespaces=NS):
+        target = trans_node.find("x:target", namespaces=NS)
+        if target is None:
+            # Untranslated string, nothing to do.
+            continue
+
+        per_file = reference_index.get(trans_node.get("id"))
+        if per_file is None:
+            # String removed from the reference: leave its removal to Pontoon.
+            continue
+
+        source_node = trans_node.find("x:source", namespaces=NS)
+        if source_node is None:
+            # Malformed locale unit; log and skip.
+            print(
+                f"WARNING: Skipping trans-unit '{trans_node.get('id')}' without source"
+            )
+            continue
+
+        reference_sources = per_file.get(file_original(trans_node))
+        if reference_sources is None:
+            # The ID exists in the reference but only in a different <file>: the
+            # string moved, leave it in place ('nofile'/'matchid' relocate it).
+            continue
+
+        # Same file: remove only when the source text actually changed here.
+        if source_node.text not in reference_sources:
+            target.getparent().remove(target)
+
+
+def carry_over_obsolete(new_root, locale_root, reference_ids, locale_code):
+    """
+    Keep strings that no longer exist in the reference (removed upstream) in the
+    rebuilt localized file, so their removal is left to Pontoon instead of the
+    automation dropping them. This applies to translated and untranslated
+    strings alike, so removing a string upstream doesn't touch localized files
+    here. Each obsolete string is reinserted in its original position (right
+    after its previous surviving sibling), to avoid unnecessary reordering.
+
+    - new_root: the freshly rebuilt tree (a deepcopy of the reference structure,
+                with translations already injected).
+    - locale_root: the original localized file's content (the source of truth
+                   for what obsolete strings existed and where).
+    - reference_ids: set of every trans-unit ID that still exists in the
+                     reference. An ID not in this set = obsolete.
+    """
+
+    new_file_nodes = {
+        fn.get("original"): fn for fn in new_root.xpath("//x:file", namespaces=NS)
+    }
+    for loc_file in locale_root.xpath("//x:file", namespaces=NS):
+        units = loc_file.xpath("./x:body/x:trans-unit", namespaces=NS)
+        if all(tu.get("id") in reference_ids for tu in units):
+            # Nothing obsolete in this <file> block.
+            continue
+
+        original = loc_file.get("original")
+        dest = new_file_nodes.get(original)
+        if dest is None:
+            # The whole <file> block is gone from the reference: recreate it
+            # (empty), preserving the <file> attributes. Obsolete strings
+            # will be reinserted below.
+            dest = deepcopy(loc_file)
+            dest.set("target-language", locale_code)
+            dest_body = dest.find("x:body", namespaces=NS)
+            for tu in dest_body.xpath("./x:trans-unit", namespaces=NS):
+                dest_body.remove(tu)
+            new_root.append(dest)
+            new_file_nodes[original] = dest
+        else:
+            dest_body = dest.find("x:body", namespaces=NS)
+
+        # Index the units already placed in the rebuilt block, to
+        # anchor each obsolete unit after its previous sibling.
+        dest_index = {}
+        for cand in dest_body.xpath("./x:trans-unit", namespaces=NS):
+            dest_index.setdefault(cand.get("id"), cand)
+
+        # Walk the localized units in order, reinserting the obsolete ones.
+        anchor = None
+        for tu in units:
+            tid = tu.get("id")
+            if tid in reference_ids:
+                # Surviving unit already in the rebuilt block: use as anchor.
+                anchor = dest_index.get(tid, anchor)
+            else:
+                copy = deepcopy(tu)
+                if anchor is None:
+                    dest_body.insert(0, copy)
+                else:
+                    anchor.addnext(copy)
+                anchor = copy
+
+
+def rebuild_from_reference(reference_tree, locale_root, update_type, locale_code):
+    """
+    'nofile'/'matchid' mode: return a new localized tree built from the
+    reference structure, with existing translations injected. Because it's
+    based on the reference, strings that moved to a different <file> block are
+    re-emitted (with their translation) under their new location. Translations
+    for strings removed upstream are carried over (see carry_over_obsolete).
+
+    'locale_root' is the current localized content of an existing file.
+    """
+    # Remember each localized <file>'s attribute order, to restore it on the
+    # rebuilt tree (which otherwise inherits the reference's order).
+    locale_file_attr_order = {
+        fn.get("original"): list(fn.attrib.keys())
+        for fn in locale_root.xpath("//x:file", namespaces=NS)
+    }
+
+    # Collect existing translations, keyed according to the update type. Keep a
+    # per-file map so a shared ID (e.g. iOS default IDs reused across files with
+    # different translations) can't clobber another file's translation, plus a
+    # file-agnostic fallback used *only* to relocate a translation whose string
+    # moved to a different <file> block.
+    translations_by_file = {}
+    translations_any = {}
+    for trans_node in locale_root.xpath("//x:trans-unit", namespaces=NS):
+        target = trans_node.find("x:target", namespaces=NS)
+        if target is None:
+            continue
+        source_node = trans_node.find("x:source", namespaces=NS)
+        source_string = source_node.text if source_node is not None else None
+        key = translation_key(update_type, trans_node.get("id"), source_string)
+        translations_by_file[(file_original(trans_node), key)] = target.text
+        translations_any.setdefault(key, target.text)
+
+    # Build the new localized tree from the reference structure.
+    new_tree = deepcopy(reference_tree)
+    new_root = new_tree.getroot()
+
+    reference_ids = {
+        tu.get("id") for tu in new_root.xpath("//x:trans-unit", namespaces=NS)
+    }
+
+    for trans_node in new_root.xpath("//x:trans-unit", namespaces=NS):
+        source_node = trans_node.find("x:source", namespaces=NS)
+        source_string = source_node.text if source_node is not None else None
+        key = translation_key(update_type, trans_node.get("id"), source_string)
+
+        # Prefer the translation from the same file; fall back to any file only
+        # to relocate a string that moved to a different <file> block.
+        file_key = (file_original(trans_node), key)
+        if file_key in translations_by_file:
+            translation = translations_by_file[file_key]
+            has_translation = True
+        elif key in translations_any:
+            translation = translations_any[key]
+            has_translation = True
+        else:
+            has_translation = False
+
+        existing_target = trans_node.find("x:target", namespaces=NS)
+        if has_translation:
+            if existing_target is not None:
+                existing_target.text = translation
+            else:
+                # Insert a new <target> right after <source>, in the XLIFF
+                # namespace so the in-memory tree matches what is written to
+                # disk (a bare etree.Element("target") would be namespaceless
+                # in memory and only pick up the default namespace on save).
+                target = etree.Element(f"{{{NS['x']}}}target")
+                target.text = translation
+                source_index = list(trans_node).index(source_node)
+                trans_node.insert(source_index + 1, target)
+        elif existing_target is not None:
+            # No translation available, remove the target.
+            existing_target.getparent().remove(existing_target)
+
+    # Preserve strings removed from the reference (see carry_over_obsolete).
+    # This prevents the diff from growing unnecessarily, leaving the removal
+    # to Pontoon instead, and reducing merge conflicts.
+    carry_over_obsolete(new_root, locale_root, reference_ids, locale_code)
+
+    # Set the target-language on every <file> node to the locale code, and
+    # restore the localized file's attribute order to avoid noise diffs.
+    for file_node in new_root.xpath("//x:file", namespaces=NS):
+        file_node.set("target-language", locale_code)
+        preferred = locale_file_attr_order.get(file_node.get("original"))
+        if preferred:
+            reorder_attributes(file_node, preferred)
+
+    return new_tree
 
 
 def main():
@@ -62,10 +321,19 @@ def main():
         required=False,
         default="standard",
         dest="update_type",
-        help="""Type of update. Existing translation is maintained if:
-    - 'standard': matches file, ID, and source text
-    - 'nofile': matches ID and source text, ignoring file
-    - 'matchid': matches ID""",
+        help="""Type of update:
+    - 'standard': in place, remove a translation only if the source changed
+    - 'nofile': rebuild from reference, move translations if ID and source text match
+    - 'matchid': rebuild from reference, move translations if ID matches (ignore source text)""",
+    )
+
+    parser.add_argument(
+        "--project",
+        required=False,
+        default=None,
+        choices=sorted(PROJECTS),
+        help="Project config to use (locale mapping + excluded folders).\n"
+        "Defaults to no mapping and no excluded folders.",
     )
 
     parser.add_argument("locales", nargs="*", help="Locales to process")
@@ -73,6 +341,9 @@ def main():
 
     reference_locale = args.reference_locale
     update_type = args.update_type
+    config = get_project_config(args.project)
+    mapping = config["mapping"]
+    excluded_folders = config["excluded_folders"]
 
     # Get a list of files to update (absolute paths)
     base_folder = os.path.realpath(args.base_folder)
@@ -87,21 +358,13 @@ def main():
             f"No reference file found in {os.path.join(base_folder, reference_locale)}"
         )
 
-    # Get the list of locales. 'templates' is generated separately, and 'es' is
-    # a copy of es-ES maintained via workflow, so both are excluded together
-    # with the reference locale.
+    # Get the list of locales
     if args.locales:
         locales = args.locales
     else:
-        locales = [
-            d
-            for d in os.listdir(base_folder)
-            if os.path.isdir(os.path.join(base_folder, d)) and not d.startswith(".")
-        ]
-        for excluded in (reference_locale, "templates", "es"):
-            if excluded in locales:
-                locales.remove(excluded)
-        locales.sort()
+        locales = list_locales(
+            base_folder, excluded=excluded_folders, skip={reference_locale}
+        )
 
     updated_files = 0
     for filename in reference_files:
@@ -113,101 +376,56 @@ def main():
         except Exception as e:
             sys.exit(f"ERROR: Can't parse reference file {filename}\n{e}")
 
-        """
-        Build an index of the reference content, keyed by trans-unit ID.
-        Each ID maps to the list of (file, source) pairs where it appears:
-        the same ID can be reused in different files (e.g. common keys like "
-        OK" or "Cancel"), so it isn't unique on its own.
-        """
-        reference_index = {}
-        for trans_node in reference_root.xpath("//x:trans-unit", namespaces=NS):
-            source = trans_node.find("x:source", namespaces=NS)
-            if source is None:
-                # A reference unit without a source means a broken extraction.
-                # Exit with an error.
-                sys.exit(
-                    f"ERROR: Reference trans-unit '{trans_node.get('id')}' "
-                    f"has no source in {filename}"
-                )
-            original_id = trans_node.get("id")
-            file_name = trans_node.getparent().getparent().get("original")
-            reference_index.setdefault(original_id, []).append(
-                (file_name, source.text)
-            )
+        # 'standard' only needs an index of the reference sources per ID.
+        reference_index = (
+            build_reference_index(reference_root, filename)
+            if update_type == "standard"
+            else None
+        )
 
         for locale in locales:
             l10n_file = os.path.join(base_folder, locale, filename)
-            if not os.path.isfile(l10n_file):
-                continue
 
-            print(f"Processing {l10n_file}")
-
-            # Read localized XML file
-            try:
-                locale_tree = etree.parse(l10n_file)
-                locale_root = locale_tree.getroot()
-            except Exception as e:
-                print(f"ERROR: Can't parse {l10n_file}")
-                print(e)
-                continue
-
-            for trans_node in locale_root.xpath("//x:trans-unit", namespaces=NS):
-                targets = trans_node.xpath("./x:target", namespaces=NS)
-                if not targets:
-                    # Untranslated string, nothing to do.
-                    continue
-                target = targets[0]
-
-                original_id = trans_node.get("id")
-                reference_entries = reference_index.get(original_id)
-                if reference_entries is None:
-                    # Obsolete string, not available in reference content.
-                    # Leave its removal to Pontoon.
+            if update_type == "standard":
+                # In-place update, requires an existing localized file.
+                if not os.path.isfile(l10n_file):
                     continue
 
-                source_node = trans_node.find("x:source", namespaces=NS)
-                if source_node is None:
-                    # Malformed locale unit; log and skip.
-                    print(
-                        f"WARNING: Skipping trans-unit '{trans_node.get('id')}' "
-                        f"without source in {l10n_file}"
-                    )
-                    continue
-                file_name = trans_node.getparent().getparent().get("original")
-                source_string = source_node.text
-
-                if update_type == "matchid":
-                    # Keep the translation and align the source to the reference.
-                    # Prefer the entry from the same file, since an ID can appear
-                    # in more than one file; otherwise fall back to the first.
-                    reference_source = reference_entries[0][1]
-                    for ref_file, ref_source in reference_entries:
-                        if ref_file == file_name:
-                            reference_source = ref_source
-                            break
-                    if source_string != reference_source:
-                        source_node.text = reference_source
+                print(f"Processing {l10n_file}")
+                try:
+                    locale_tree = etree.parse(l10n_file)
+                    locale_root = locale_tree.getroot()
+                except Exception as e:
+                    print(f"ERROR: Can't parse {l10n_file}")
+                    print(e)
                     continue
 
-                if update_type == "nofile":
-                    # Keep if any reference entry has the same source.
-                    keep = any(
-                        source_string == ref_source
-                        for _, ref_source in reference_entries
-                    )
-                else:
-                    # 'standard': keep if a reference entry matches file and source.
-                    keep = any(
-                        file_name == ref_file and source_string == ref_source
-                        for ref_file, ref_source in reference_entries
-                    )
+                update_in_place(reference_index, locale_root)
+                write_xliff(locale_tree, l10n_file)
+                updated_files += 1
+            else:
+                # Rebuild from reference, moving existing translations. Requires an
+                # existing localized file: a missing file would only be rebuilt
+                # with no translations, so leave its creation to Pontoon.
+                if not os.path.isfile(l10n_file):
+                    continue
 
-                if not keep:
-                    target.getparent().remove(target)
+                print(f"Updating {l10n_file}")
+                try:
+                    locale_root = etree.parse(l10n_file).getroot()
+                except Exception as e:
+                    print(f"ERROR: Can't parse {l10n_file}")
+                    print(e)
+                    continue
 
-            # Replace the existing locale file with the updated XML content
-            write_xliff(locale_tree, l10n_file)
-            updated_files += 1
+                # Resolve the folder name to its XLIFF target-language code.
+                locale_code = get_locale_code(mapping, locale)
+
+                new_tree = rebuild_from_reference(
+                    reference_tree, locale_root, update_type, locale_code
+                )
+                write_xliff(new_tree, l10n_file)
+                updated_files += 1
 
     if updated_files == 0:
         sys.exit("No files updated.")

--- a/.github/scripts/update_other_locales.py
+++ b/.github/scripts/update_other_locales.py
@@ -188,27 +188,49 @@ def carry_over_obsolete(new_root, locale_root, reference_ids, locale_code):
     new_file_nodes = {
         fn.get("original"): fn for fn in new_root.xpath("//x:file", namespaces=NS)
     }
+    # Track the last surviving <file> in the rebuilt tree, so a <file> block
+    # removed upstream can be reinserted in its original position (right after
+    # the previous surviving <file>) instead of being appended at the end,
+    # which would create a reordering diff.
+    file_anchor = None
     for loc_file in locale_root.xpath("//x:file", namespaces=NS):
-        old_loc_trans_units = loc_file.xpath("./x:body/x:trans-unit", namespaces=NS)
-        if all(tu.get("id") in reference_ids for tu in old_loc_trans_units):
-            # Nothing obsolete in this <file> block.
-            continue
-
         original = loc_file.get("original")
         new_dest = new_file_nodes.get(original)
-        if new_dest is None:
+
+        old_loc_trans_units = loc_file.xpath("./x:body/x:trans-unit", namespaces=NS)
+        nothing_obsolete = all(
+            tu.get("id") in reference_ids for tu in old_loc_trans_units
+        )
+
+        if new_dest is not None:
+            # This <file> still exists in the reference; it anchors the
+            # position of any following removed <file> block.
+            file_anchor = new_dest
+            if nothing_obsolete:
+                continue
+            new_dest_body = new_dest.find("x:body", namespaces=NS)
+        else:
+            if nothing_obsolete:
+                # The <file> is gone from the reference but all its strings
+                # only moved elsewhere (still in reference_ids); they are
+                # re-emitted under their new <file>, so nothing to carry over.
+                continue
             # The whole <file> block was removed from the reference: recreate
             # it and empty its <body> (no <trans-unit> elements), preserving
-            # the <file> attributes. Obsolete strings will be reinserted later.
+            # the <file> attributes. Insert it in its original position, right
+            # after the previous surviving <file> (or first if none precedes
+            # it), to avoid reordering. Obsolete strings are reinserted later.
             new_dest = deepcopy(loc_file)
             new_dest.set("target-language", locale_code)
             new_dest_body = new_dest.find("x:body", namespaces=NS)
             for tu in new_dest_body.xpath("./x:trans-unit", namespaces=NS):
                 new_dest_body.remove(tu)
-            new_root.append(new_dest)
+            if file_anchor is None:
+                new_root.insert(0, new_dest)
+            else:
+                file_anchor.addnext(new_dest)
             new_file_nodes[original] = new_dest
-        else:
-            new_dest_body = new_dest.find("x:body", namespaces=NS)
+            file_anchor = new_dest
 
         # At this point, new_dest_body is the <file><body> of the new XLIFF
         # tree, rebuilt from the reference and already containing any

--- a/.github/scripts/update_other_locales.py
+++ b/.github/scripts/update_other_locales.py
@@ -313,7 +313,15 @@ def rebuild_from_reference(reference_tree, locale_root, update_type, locale_code
 
     for file_original, trans_node in iter_units_by_filenode(new_root):
         source_node = trans_node.find("x:source", namespaces=NS)
-        source_string = source_node.text if source_node is not None else None
+        if source_node is None:
+            # Malformed reference unit (broken extraction): can't match or
+            # inject a translation without a <source> to anchor it.
+            # Log and skip.
+            print(
+                f"WARNING: Skipping trans-unit '{trans_node.get('id')}' without source"
+            )
+            continue
+        source_string = source_node.text
         key = translation_key(update_type, trans_node.get("id"), source_string)
 
         # Prefer the translation from the same file; fall back to any file only

--- a/.github/scripts/update_other_locales.py
+++ b/.github/scripts/update_other_locales.py
@@ -77,9 +77,16 @@ def translation_key(update_type, original_id, source_string):
     return f"{original_id}:{hash(source_string)}"
 
 
-def file_original(trans_node):
-    """Return the 'original' attribute of the <file> a trans-unit belongs to."""
-    return trans_node.xpath("ancestor::x:file", namespaces=NS)[0].get("original")
+def iter_units_by_filenode(root):
+    """
+    Yield (original, trans_node) for every <trans-unit> in the tree.
+
+    Iterating by <file> lets us read each file's 'original' attribute once.
+    """
+    for file_node in root.xpath("//x:file", namespaces=NS):
+        original = file_node.get("original")
+        for trans_node in file_node.xpath(".//x:trans-unit", namespaces=NS):
+            yield original, trans_node
 
 
 def reorder_attributes(node, preferred_order):
@@ -111,7 +118,7 @@ def build_reference_index(reference_root, filename):
     extractions.
     """
     reference_index = {}
-    for trans_node in reference_root.xpath("//x:trans-unit", namespaces=NS):
+    for file_original, trans_node in iter_units_by_filenode(reference_root):
         source = trans_node.find("x:source", namespaces=NS)
         tu_id = trans_node.get("id")
         if source is None:
@@ -120,7 +127,7 @@ def build_reference_index(reference_root, filename):
                 f"ERROR: Reference trans-unit '{tu_id}' has no source in {filename}"
             )
         sources_by_id = reference_index.setdefault(tu_id, {})
-        sources_by_id.setdefault(file_original(trans_node), set()).add(source.text)
+        sources_by_id.setdefault(file_original, set()).add(source.text)
     return reference_index
 
 
@@ -131,7 +138,7 @@ def update_in_place(reference_index, locale_root):
     different <file> and its source text changed. Strings removed upstream,
     and pure moves where the source text is unchanged, are left untouched.
     """
-    for trans_node in locale_root.xpath("//x:trans-unit", namespaces=NS):
+    for file_original, trans_node in iter_units_by_filenode(locale_root):
         target = trans_node.find("x:target", namespaces=NS)
         if target is None:
             # Untranslated string, nothing to do.
@@ -150,7 +157,7 @@ def update_in_place(reference_index, locale_root):
             print(f"WARNING: Skipping trans-unit '{tu_id}' without source")
             continue
 
-        files_for_id = sources_by_id.get(file_original(trans_node))
+        files_for_id = sources_by_id.get(file_original)
         if files_for_id is None:
             # The ID exists in the reference but only in a different <file>: the
             # string moved. A pure move (source text unchanged) is left in place
@@ -194,8 +201,8 @@ def carry_over_obsolete(new_root, locale_root, reference_ids, locale_code):
     # which would create a reordering diff.
     file_anchor = None
     for loc_file in locale_root.xpath("//x:file", namespaces=NS):
-        original = loc_file.get("original")
-        new_dest = new_file_nodes.get(original)
+        file_original = loc_file.get("original")
+        new_dest = new_file_nodes.get(file_original)
 
         old_loc_trans_units = loc_file.xpath("./x:body/x:trans-unit", namespaces=NS)
         nothing_obsolete = all(
@@ -229,7 +236,7 @@ def carry_over_obsolete(new_root, locale_root, reference_ids, locale_code):
                 new_root.insert(0, new_dest)
             else:
                 file_anchor.addnext(new_dest)
-            new_file_nodes[original] = new_dest
+            new_file_nodes[file_original] = new_dest
             file_anchor = new_dest
 
         # At this point, new_dest_body is the <file><body> of the new XLIFF
@@ -286,14 +293,14 @@ def rebuild_from_reference(reference_tree, locale_root, update_type, locale_code
     # moved to a different <file> block.
     translations_by_file = {}
     translations_any = {}
-    for trans_node in locale_root.xpath("//x:trans-unit", namespaces=NS):
+    for file_original, trans_node in iter_units_by_filenode(locale_root):
         target = trans_node.find("x:target", namespaces=NS)
         if target is None:
             continue
         source_node = trans_node.find("x:source", namespaces=NS)
         source_string = source_node.text if source_node is not None else None
         key = translation_key(update_type, trans_node.get("id"), source_string)
-        translations_by_file[(file_original(trans_node), key)] = target.text
+        translations_by_file[(file_original, key)] = target.text
         translations_any.setdefault(key, target.text)
 
     # Build the new localized tree from the reference structure.
@@ -304,14 +311,14 @@ def rebuild_from_reference(reference_tree, locale_root, update_type, locale_code
         tu.get("id") for tu in new_root.xpath("//x:trans-unit", namespaces=NS)
     }
 
-    for trans_node in new_root.xpath("//x:trans-unit", namespaces=NS):
+    for file_original, trans_node in iter_units_by_filenode(new_root):
         source_node = trans_node.find("x:source", namespaces=NS)
         source_string = source_node.text if source_node is not None else None
         key = translation_key(update_type, trans_node.get("id"), source_string)
 
         # Prefer the translation from the same file; fall back to any file only
         # to relocate a string that moved to a different <file> block.
-        file_key = (file_original(trans_node), key)
+        file_key = (file_original, key)
         if file_key in translations_by_file:
             translation = translations_by_file[file_key]
             has_translation = True

--- a/.github/scripts/update_other_locales.py
+++ b/.github/scripts/update_other_locales.py
@@ -5,7 +5,12 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 """
-update_other_locales.py --reference <locale> --path <folder> [locales...]
+update_other_locales.py --reference <locale> --path <folder>
+     [--type standard|nofile|matchid] [--project <name>] [locales...]
+
+ --project selects the locale mapping and excluded folders from
+ locale_config.py. When no project name is provided, empty defaults are used
+ (no remapping, no excluded folders).
 
  How each localized file is updated depends on the '--type' argument. The two
  behaviors exist because they serve different goals.
@@ -16,12 +21,13 @@ update_other_locales.py --reference <locale> --path <folder> [locales...]
  by Pontoon (same <file> and <trans-unit> elements), so this mode only edits
  translations in place and never adds, removes, or reorders <trans-unit> elements.
 
- A localized <target> is removed *only* when the source text of that string
- changed in the reference, without using a new ID. In every other case the
- localized file is left untouched:
- - String removed from the reference are left in place (Pontoon will remove them).
- - String moved to a different file are left in place. 'nofile'/'matchid'
-   should be used to actually move the translation).
+ A localized <target> is removed when the source text of that string changed
+ in the reference (same ID, same file). It is also removed when the string
+ moved to a different <file> and its source text changed.
+ In every other case the localized file is left untouched:
+ - Strings removed from the reference are left in place (Pontoon will remove them).
+ - Strings moved to a different file with an unchanged source are left in place
+   ('nofile'/'matchid' relocate the translation; Pontoon syncs the structure).
 
  'nofile' / 'matchid' (rebuild from reference, move existing translations)
  -------------------------------------------------------------------------
@@ -95,26 +101,35 @@ def reorder_attributes(node, preferred_order):
 def build_reference_index(reference_root, filename):
     """
     Index the reference content as {id: {original_file: set(sources)}}.
+
+    This structure is necessary to differentiate strings with the same ID but
+    placed in different <file> blocks (e.g. CFBundleDisplayName in iOS),
+    possibly with different source text.
+
+    Using a set() should be unnecessary, since the same ID shouldn't appear
+    more than once in the same <file> block, but it protects against broken
+    extractions.
     """
     reference_index = {}
     for trans_node in reference_root.xpath("//x:trans-unit", namespaces=NS):
         source = trans_node.find("x:source", namespaces=NS)
+        tu_id = trans_node.get("id")
         if source is None:
             # A reference unit without a source means a broken extraction.
             sys.exit(
-                f"ERROR: Reference trans-unit '{trans_node.get('id')}' "
-                f"has no source in {filename}"
+                f"ERROR: Reference trans-unit '{tu_id}' has no source in {filename}"
             )
-        per_file = reference_index.setdefault(trans_node.get("id"), {})
-        per_file.setdefault(file_original(trans_node), set()).add(source.text)
+        sources_by_id = reference_index.setdefault(tu_id, {})
+        sources_by_id.setdefault(file_original(trans_node), set()).add(source.text)
     return reference_index
 
 
 def update_in_place(reference_index, locale_root):
     """
-    'standard' mode: remove a localized <target> only when the source text
-    changed in the reference for the same XLIFF file. Strings removed upstream
-    or moved to a different file are left untouched.
+    'standard' mode: remove a localized <target> when the source text changed
+    in the reference for the same XLIFF file, or when the string moved to a
+    different <file> and its source text changed. Strings removed upstream,
+    and pure moves where the source text is unchanged, are left untouched.
     """
     for trans_node in locale_root.xpath("//x:trans-unit", namespaces=NS):
         target = trans_node.find("x:target", namespaces=NS)
@@ -122,27 +137,34 @@ def update_in_place(reference_index, locale_root):
             # Untranslated string, nothing to do.
             continue
 
-        per_file = reference_index.get(trans_node.get("id"))
-        if per_file is None:
-            # String removed from the reference: leave its removal to Pontoon.
+        tu_id = trans_node.get("id")
+        sources_by_id = reference_index.get(tu_id)
+        if sources_by_id is None:
+            # String was completely removed from the reference. Pontoon will
+            # remove it on next sync, so leave it in place here to avoid noise.
             continue
 
         source_node = trans_node.find("x:source", namespaces=NS)
         if source_node is None:
             # Malformed locale unit; log and skip.
-            print(
-                f"WARNING: Skipping trans-unit '{trans_node.get('id')}' without source"
-            )
+            print(f"WARNING: Skipping trans-unit '{tu_id}' without source")
             continue
 
-        reference_sources = per_file.get(file_original(trans_node))
-        if reference_sources is None:
+        files_for_id = sources_by_id.get(file_original(trans_node))
+        if files_for_id is None:
             # The ID exists in the reference but only in a different <file>: the
-            # string moved, leave it in place ('nofile'/'matchid' relocate it).
+            # string moved. A pure move (source text unchanged) is left in place
+            # ('nofile'/'matchid' can relocate the translation). If the source
+            # text also changed, the translation is stale, so drop the target.
+            all_sources = set()
+            for file_sources in sources_by_id.values():
+                all_sources.update(file_sources)
+            if source_node.text not in all_sources:
+                target.getparent().remove(target)
             continue
 
         # Same file: remove only when the source text actually changed here.
-        if source_node.text not in reference_sources:
+        if source_node.text not in files_for_id:
             target.getparent().remove(target)
 
 
@@ -160,51 +182,55 @@ def carry_over_obsolete(new_root, locale_root, reference_ids, locale_code):
     - locale_root: the original localized file's content (the source of truth
                    for what obsolete strings existed and where).
     - reference_ids: set of every trans-unit ID that still exists in the
-                     reference. An ID not in this set = obsolete.
+                     reference. An ID not in this set = obsolete string.
     """
 
     new_file_nodes = {
         fn.get("original"): fn for fn in new_root.xpath("//x:file", namespaces=NS)
     }
     for loc_file in locale_root.xpath("//x:file", namespaces=NS):
-        units = loc_file.xpath("./x:body/x:trans-unit", namespaces=NS)
-        if all(tu.get("id") in reference_ids for tu in units):
+        old_loc_trans_units = loc_file.xpath("./x:body/x:trans-unit", namespaces=NS)
+        if all(tu.get("id") in reference_ids for tu in old_loc_trans_units):
             # Nothing obsolete in this <file> block.
             continue
 
         original = loc_file.get("original")
-        dest = new_file_nodes.get(original)
-        if dest is None:
-            # The whole <file> block is gone from the reference: recreate it
-            # (empty), preserving the <file> attributes. Obsolete strings
-            # will be reinserted below.
-            dest = deepcopy(loc_file)
-            dest.set("target-language", locale_code)
-            dest_body = dest.find("x:body", namespaces=NS)
-            for tu in dest_body.xpath("./x:trans-unit", namespaces=NS):
-                dest_body.remove(tu)
-            new_root.append(dest)
-            new_file_nodes[original] = dest
+        new_dest = new_file_nodes.get(original)
+        if new_dest is None:
+            # The whole <file> block was removed from the reference: recreate
+            # it and empty its <body> (no <trans-unit> elements), preserving
+            # the <file> attributes. Obsolete strings will be reinserted later.
+            new_dest = deepcopy(loc_file)
+            new_dest.set("target-language", locale_code)
+            new_dest_body = new_dest.find("x:body", namespaces=NS)
+            for tu in new_dest_body.xpath("./x:trans-unit", namespaces=NS):
+                new_dest_body.remove(tu)
+            new_root.append(new_dest)
+            new_file_nodes[original] = new_dest
         else:
-            dest_body = dest.find("x:body", namespaces=NS)
+            new_dest_body = new_dest.find("x:body", namespaces=NS)
 
+        # At this point, new_dest_body is the <file><body> of the new XLIFF
+        # tree, rebuilt from the reference and already containing any
+        # surviving translations. If the <file> was completely removed
+        # from the reference, new_dest_body is empty.
         # Index the units already placed in the rebuilt block, to
         # anchor each obsolete unit after its previous sibling.
-        dest_index = {}
-        for cand in dest_body.xpath("./x:trans-unit", namespaces=NS):
-            dest_index.setdefault(cand.get("id"), cand)
+        new_dest_index = {}
+        for tu_candidate in new_dest_body.xpath("./x:trans-unit", namespaces=NS):
+            new_dest_index.setdefault(tu_candidate.get("id"), tu_candidate)
 
         # Walk the localized units in order, reinserting the obsolete ones.
         anchor = None
-        for tu in units:
-            tid = tu.get("id")
-            if tid in reference_ids:
+        for tu in old_loc_trans_units:
+            tu_id = tu.get("id")
+            if tu_id in reference_ids:
                 # Surviving unit already in the rebuilt block: use as anchor.
-                anchor = dest_index.get(tid, anchor)
+                anchor = new_dest_index.get(tu_id, anchor)
             else:
                 copy = deepcopy(tu)
                 if anchor is None:
-                    dest_body.insert(0, copy)
+                    new_dest_body.insert(0, copy)
                 else:
                     anchor.addnext(copy)
                 anchor = copy
@@ -217,11 +243,15 @@ def rebuild_from_reference(reference_tree, locale_root, update_type, locale_code
     based on the reference, strings that moved to a different <file> block are
     re-emitted (with their translation) under their new location. Translations
     for strings removed upstream are carried over (see carry_over_obsolete).
+    That prevents automation from touching localized files, leaving the removal
+    to Pontoon instead, and reducing merge conflicts.
 
     'locale_root' is the current localized content of an existing file.
     """
     # Remember each localized <file>'s attribute order, to restore it on the
     # rebuilt tree (which otherwise inherits the reference's order).
+    # Without this, different automations (this script, extraction, Pontoon)
+    # would start fighting over the attribute order, creating unnecessary diffs.
     locale_file_attr_order = {
         fn.get("original"): list(fn.attrib.keys())
         for fn in locale_root.xpath("//x:file", namespaces=NS)
@@ -230,7 +260,7 @@ def rebuild_from_reference(reference_tree, locale_root, update_type, locale_code
     # Collect existing translations, keyed according to the update type. Keep a
     # per-file map so a shared ID (e.g. iOS default IDs reused across files with
     # different translations) can't clobber another file's translation, plus a
-    # file-agnostic fallback used *only* to relocate a translation whose string
+    # file-agnostic fallback used only to relocate a translation whose string
     # moved to a different <file> block.
     translations_by_file = {}
     translations_any = {}
@@ -280,8 +310,7 @@ def rebuild_from_reference(reference_tree, locale_root, update_type, locale_code
                 # in memory and only pick up the default namespace on save).
                 target = etree.Element(f"{{{NS['x']}}}target")
                 target.text = translation
-                source_index = list(trans_node).index(source_node)
-                trans_node.insert(source_index + 1, target)
+                source_node.addnext(target)
         elif existing_target is not None:
             # No translation available, remove the target.
             existing_target.getparent().remove(existing_target)
@@ -308,13 +337,13 @@ def main():
         "--reference",
         required=True,
         dest="reference_locale",
-        help="Reference locale code",
+        help="Locale code for source strings (usually en-US)",
     )
     parser.add_argument(
         "--path",
         required=True,
         dest="base_folder",
-        help="Path to folder including subfolders for all locales",
+        help="Path to folder containing subfolders for all locales",
     )
     parser.add_argument(
         "--type",
@@ -336,7 +365,12 @@ def main():
         "Defaults to no mapping and no excluded folders.",
     )
 
-    parser.add_argument("locales", nargs="*", help="Locales to process")
+    parser.add_argument(
+        "locales",
+        nargs="*",
+        help="Locales to process; if none are listed, all locale subfolders "
+        "in the path will be processed",
+    )
     args = parser.parse_args()
 
     reference_locale = args.reference_locale
@@ -377,6 +411,7 @@ def main():
             sys.exit(f"ERROR: Can't parse reference file {filename}\n{e}")
 
         # 'standard' only needs an index of the reference sources per ID.
+        # Build once here instead of within the locale loop.
         reference_index = (
             build_reference_index(reference_root, filename)
             if update_type == "standard"
@@ -386,49 +421,42 @@ def main():
         for locale in locales:
             l10n_file = os.path.join(base_folder, locale, filename)
 
+            # Every mode requires an existing localized file. In rebuild modes a
+            # missing file would only be recreated with no translations, so its
+            # creation is left to Pontoon.
+            if not os.path.isfile(l10n_file):
+                continue
+
+            try:
+                locale_tree = etree.parse(l10n_file)
+                locale_root = locale_tree.getroot()
+            except Exception as e:
+                print(f"ERROR: Can't parse {l10n_file}")
+                print(e)
+                continue
+
             if update_type == "standard":
-                # In-place update, requires an existing localized file.
-                if not os.path.isfile(l10n_file):
-                    continue
-
+                # In-place update.
                 print(f"Processing {l10n_file}")
-                try:
-                    locale_tree = etree.parse(l10n_file)
-                    locale_root = locale_tree.getroot()
-                except Exception as e:
-                    print(f"ERROR: Can't parse {l10n_file}")
-                    print(e)
-                    continue
-
                 update_in_place(reference_index, locale_root)
                 write_xliff(locale_tree, l10n_file)
-                updated_files += 1
             else:
-                # Rebuild from reference, moving existing translations. Requires an
-                # existing localized file: a missing file would only be rebuilt
-                # with no translations, so leave its creation to Pontoon.
-                if not os.path.isfile(l10n_file):
-                    continue
-
+                # Rebuild from reference, moving existing translations.
                 print(f"Updating {l10n_file}")
-                try:
-                    locale_root = etree.parse(l10n_file).getroot()
-                except Exception as e:
-                    print(f"ERROR: Can't parse {l10n_file}")
-                    print(e)
-                    continue
-
                 # Resolve the folder name to its XLIFF target-language code.
                 locale_code = get_locale_code(mapping, locale)
-
                 new_tree = rebuild_from_reference(
                     reference_tree, locale_root, update_type, locale_code
                 )
                 write_xliff(new_tree, l10n_file)
-                updated_files += 1
+
+            updated_files += 1
 
     if updated_files == 0:
-        sys.exit("No files updated.")
+        # No localized file matched the reference (e.g. a brand-new project that
+        # isn't localized yet). This is not an error: exit cleanly so a first
+        # import doesn't fail CI, leaving the file creation to Pontoon.
+        print("WARNING: No localized files to update.")
     else:
         print(f"{updated_files} files processed.")
 

--- a/.github/workflows/check_target_language.yml
+++ b/.github/workflows/check_target_language.yml
@@ -25,4 +25,4 @@ jobs:
           pip install -r .github/scripts/requirements.txt
       - name: Check target-language
         run: |
-          python .github/scripts/check_target_language.py --path .
+          python .github/scripts/check_target_language.py --path . --project ios

--- a/.github/workflows/import_strings.yml
+++ b/.github/workflows/import_strings.yml
@@ -75,7 +75,7 @@ jobs:
           python .github/scripts/create_templates.py --reference ./en-US --output ./templates
 
           # Update translations in localized files where necessary
-          python .github/scripts/update_other_locales.py --reference en-US --path . --type "$TYPE"
+          python .github/scripts/update_other_locales.py --reference en-US --path . --project ios --type "$TYPE"
         working-directory: l10n_repo
       - name: Import linter config
         run: |


### PR DESCRIPTION
Unfortunately, it turns out I was naive in my rewrite, completely breaking the `nofile`/`matchid` options, and introducing some unexpected behavior even in standard mode.

## `standard` mode

When a trans-unit moves between `<file>` elements, the translation gets removed. This is unnecessary, since the goal is to minimize the diff, and let Pontoon deal with clean-ups.

## `nofile`/`matchid` mode

In the same scenario, the translation is not carried over, since we're not rebuilding the localized file from reference anymore 🤦‍♂️.

This rewrites fixes both issues. In order to make portability between iOS and VPN easier, I've centralized some config (locale mapping, excluded folders).

I've also created a separate repository with tests, given how many weird edge cases I hit in the process: https://github.com/mozilla-l10n/xliff-l10n-scripts