### PR TITLE
Fix leaky parameter acceptance

### DIFF
--- a/.github/scripts/update_other_locales.py
+++ b/.github/scripts/update_other_locales.py
@@ -74,11 +74,8 @@ def translation_key(update_type, original_id, source_string):
     if update_type == "matchid":
         # Ignore source text: retain the translation even if the source changed.
         return original_id
-    if update_type == "nofile":
-        # Invalidate existing translation if source string changed.
-        return f"{original_id}:{hash(source_string)}"
-    # Other types added, but no behavior defined
-    raise ValueError(f"Unsupported update type '{update_type}'")
+    # nofile: Invalidate existing translation if source string changed.
+    return f"{original_id}:{hash(source_string)}"
 
 
 def iter_units_by_filenode(root):
@@ -482,7 +479,7 @@ def main():
                 print(f"Processing {l10n_file} in {update_type} mode")
                 update_in_place(reference_index, locale_root)
                 write_xliff(locale_tree, l10n_file)
-            elif update_type in ("nofile", "matchid"):
+            else:
                 # Rebuild from reference, moving existing translations.
                 print(f"Updating {l10n_file} in {update_type} mode")
                 # Resolve the folder name to its XLIFF target-language code.
@@ -491,8 +488,6 @@ def main():
                     reference_tree, locale_root, update_type, locale_code
                 )
                 write_xliff(new_tree, l10n_file)
-            else:
-                sys.exit(f"ERROR: Unknown update type '{update_type}'")
 
             updated_files += 1
 

--- a/.github/scripts/update_other_locales.py
+++ b/.github/scripts/update_other_locales.py
@@ -62,6 +62,7 @@ from locale_config import PROJECTS, get_locale_code, get_project_config
 from lxml import etree
 
 NS = {"x": "urn:oasis:names:tc:xliff:document:1.2"}
+UPDATE_TYPES = ("standard", "nofile", "matchid")
 
 
 def translation_key(update_type, original_id, source_string):
@@ -73,8 +74,11 @@ def translation_key(update_type, original_id, source_string):
     if update_type == "matchid":
         # Ignore source text: retain the translation even if the source changed.
         return original_id
-    # 'nofile': invalidate on source change.
-    return f"{original_id}:{hash(source_string)}"
+    if update_type == "nofile":
+        # Invalidate existing translation if source string changed.
+        return f"{original_id}:{hash(source_string)}"
+    # Other types added, but no behavior defined
+    raise ValueError(f"Unsupported update type '{update_type}'")
 
 
 def iter_units_by_filenode(root):
@@ -386,6 +390,7 @@ def main():
         "--type",
         required=False,
         default="standard",
+        choices=UPDATE_TYPES,
         dest="update_type",
         help="""Type of update:
     - 'standard': in place, remove a translation only if the source changed
@@ -474,18 +479,20 @@ def main():
 
             if update_type == "standard":
                 # In-place update.
-                print(f"Processing {l10n_file}")
+                print(f"Processing {l10n_file} in {update_type} mode")
                 update_in_place(reference_index, locale_root)
                 write_xliff(locale_tree, l10n_file)
-            else:
+            elif update_type in ("nofile", "matchid"):
                 # Rebuild from reference, moving existing translations.
-                print(f"Updating {l10n_file}")
+                print(f"Updating {l10n_file} in {update_type} mode")
                 # Resolve the folder name to its XLIFF target-language code.
                 locale_code = get_locale_code(mapping, locale)
                 new_tree = rebuild_from_reference(
                     reference_tree, locale_root, update_type, locale_code
                 )
                 write_xliff(new_tree, l10n_file)
+            else:
+                sys.exit(f"ERROR: Unknown update type '{update_type}'")
 
             updated_files += 1
 

--- a/.github/workflows/import_strings.yml
+++ b/.github/workflows/import_strings.yml
@@ -5,9 +5,14 @@ on:
   workflow_dispatch:
     inputs:
       type:
-        description: Type of update (standard, nofile, matchid)
+        description: Type of update
         required: true
-        default: "standard"
+        default: standard
+        type: choice
+        options:
+          - standard
+          - nofile
+          - matchid
 
 jobs:
   build:
@@ -64,7 +69,7 @@ jobs:
           cp ../firefoxios-l10n/en-US/*.xliff "${start_folder}/l10n_repo/en-US/"
       - name: Update locales
         env:
-          TYPE: ${{ github.event.inputs.type }}
+          TYPE: ${{ inputs.type || 'standard' }}
         run: |
           # Make sure that the reference locale (en-US) has translations, i.e.
           # targets defined and identical to the source. Also rewrite paths to


### PR DESCRIPTION
Fixes [Issue 2](https://github.com/mozilla-l10n/xliff-l10n-scripts/issues/2)

Scheduled runs were erroneously triggering the `nofile` type because scheduled runs have no workflow_dispatch inputs and we didn't provide an explicit fallback, so `$TYPE` was set to an **empty string** instead and passed to `update_other_locales.py` as `--type ""`. 

Additionally, before our latest changes, the standard branch was the catch-all (a generic else if the type was not exactly `nofile` or `matchid`), which meant that `--type ""` still got the "standard" treatment. With our latest changes, standard became a conditional branch and `nofile` and `matchid` became the catch-all, with some further `else` branches that lead `--type ""` to `nofile`.

This PR:
- Adds a fallback to the workflow dispatch so scheduled runs use `"standard"` instead of `""`
- For manual runs from the github interface, it turns the manual type input into a dropdown, restricted to the available options so typos are not an issue.
